### PR TITLE
Add support for 'windbg' backend instead of cdb. This allows interacting with TTD (time travel debug), live targets and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ This server provides the following tools:
 - `open_windbg_remote`: Connect to a remote debugging session using a connection string (e.g., `tcp:Port=5005,Server=192.168.0.100`)
 - `close_windbg_remote`: Disconnect from a remote debugging session and release resources
 
+### Local Debugging with WinDbg backed via .js script
+- `attach_windbg`: Connect to a local WinDbg session (instead of running cdb.exe). The session needs to load the windbg_mcp_plugin.js util (`.scriptload /path/to/windbg_mcp_plugin.js`)
+- `close_windbg_attach`: Close the channel to a running local WinDbg session.
+
 ### General Commands
 - `run_windbg_cmd`: Execute a specific WinDBG command on either a loaded crash dump or active remote session
 - `list_windbg_dumps`: List Windows crash dump (.dmp) files in the specified directory
@@ -181,6 +185,8 @@ To run the tests:
 ```bash
 pytest
 ```
+
+For live testing of attached windbg session, make sure the `DbgX.Shell.exe` process is running and that the `windbg_mcp_plugin.js` script is running inside it after `!mcp_init`
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,6 @@ build-backend = "setuptools.build_meta"
 testpaths = ["src/mcp_server_windbg/tests"]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0.0"]
+test = ["pytest>=7.0.0",
+        "psutil>=7.0.0"
+]

--- a/src/mcp_server_windbg/tests/test_server.py
+++ b/src/mcp_server_windbg/tests/test_server.py
@@ -1,0 +1,95 @@
+"""
+Tests for mcp_server_windbg.server
+
+These tests focus on logic that doesn’t require a running CDB session:
+* session caching / re-use (`get_or_create_session`)
+* unloading sessions (`unload_session`)
+* the helper that runs the four “common” WinDBG commands
+  (`execute_common_analysis_commands`)
+"""
+
+from pathlib import Path
+import importlib
+import pytest
+
+import mcp_server_windbg.server as srv
+
+
+# --------------------------------------------------------------------------- #
+#                             test utilities                                  #
+# --------------------------------------------------------------------------- #
+class DummySession:
+    """Light-weight stand-in for CDBSession."""
+
+    def __init__(self, dump_path, *_, **__):
+        self.dump_path = Path(dump_path)
+        self.commands = []
+
+    # the server helper calls this
+    def send_command(self, cmd):
+        self.commands.append(cmd)
+        return [f"dummy-output for {cmd}"]
+
+    # unload_session expects this to exist
+    def shutdown(self):
+        self.commands.append("shutdown")
+
+
+@pytest.fixture(autouse=True)
+def _clean_active_sessions():
+    """Make sure global cache is empty before / after every test."""
+    yield
+    srv.active_sessions.clear()
+
+
+@pytest.fixture
+def fake_dump(tmp_path):
+    """Create a tiny placeholder *.dmp file on disk."""
+    dmp = tmp_path / "fake.dmp"
+    dmp.write_text("dummy")
+    return dmp
+
+
+# --------------------------------------------------------------------------- #
+#                                 tests                                       #
+# --------------------------------------------------------------------------- #
+def test_get_or_create_caches(monkeypatch, fake_dump):
+    """Same dump path should return the *same* DummySession object."""
+    # Patch CDBSession → DummySession
+    monkeypatch.setattr(srv, "CDBSession", DummySession)
+
+    one = srv.get_or_create_session(str(fake_dump))
+    two = srv.get_or_create_session(str(fake_dump))
+
+    # same instance back?
+    assert one is two
+    # path stored in cache?
+    assert str(fake_dump.resolve()) in srv.active_sessions  #  get_or_create_session logic
+
+    # sanity
+    assert isinstance(one, DummySession)
+
+
+def test_unload_session(monkeypatch, fake_dump):
+    """unload_session should call shutdown() and purge the cache entry."""
+    monkeypatch.setattr(srv, "CDBSession", DummySession)
+    session = srv.get_or_create_session(str(fake_dump))
+
+    ok = srv.unload_session(str(fake_dump))  # unload_session logic
+    assert ok is True
+    # entry removed
+    assert str(fake_dump.resolve()) not in srv.active_sessions
+    # our dummy recorded the shutdown
+    assert "shutdown" in session.commands
+
+
+def test_execute_common_analysis_commands(monkeypatch, fake_dump):
+    """Helper should issue the four expected WinDBG commands in order."""
+    monkeypatch.setattr(srv, "CDBSession", DummySession)
+    session = srv.get_or_create_session(str(fake_dump))
+
+    results = srv.execute_common_analysis_commands(session)  # helper logic
+    # returned dict has exactly the expected keys
+    assert set(results) == {"info", "exception", "modules", "threads"}
+    # commands actually called on the DummySession, in the right order
+    assert session.commands == [".lastevent", "!analyze -v", "lm", "~"]

--- a/src/mcp_server_windbg/tests/test_windbg.py
+++ b/src/mcp_server_windbg/tests/test_windbg.py
@@ -1,0 +1,109 @@
+"""
+Tests for the WinDbg-attach workflow added to mcp_server_windbg.server.
+
+All tests run without a real WinDbg instance by monkey-patching
+`WinDbgSession` with a Dummy implementation.  When WinDbg *is* available
+(and the JS plug-in is initialised with `mcp_init`) the smoke-test at the
+bottom runs against the live debugger instead.
+"""
+
+from pathlib import Path
+import psutil
+import pytest
+
+import mcp_server_windbg.server as srv
+
+
+# --------------------------------------------------------------------------- #
+#                        Dummy implementation of WinDbgSession                #
+# --------------------------------------------------------------------------- #
+class DummyWinDbgSession:
+    """Light-weight replacement that records commands."""
+
+    def __init__(self, dump_path, *_, **__):
+        # In attach mode the server passes dump_path=None
+        assert dump_path is None
+        self.dump_path = None
+        self.session_id = "dummy-windbg-session"
+        self.commands: list[str] = []
+
+    def send_command(self, cmd: str):
+        self.commands.append(cmd)
+        # Return a predictable fake output line
+        return [f"dummy-windbg-out for {cmd}"]
+
+    def shutdown(self):
+        self.commands.append("shutdown")
+
+
+# --------------------------------------------------------------------------- #
+#                            automatic fixture clean-up                       #
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _clean_active_sessions():
+    """Ensure global cache is pristine for each test in this module."""
+    yield
+    srv.active_sessions.clear()
+
+
+# --------------------------------------------------------------------------- #
+#                                   tests                                     #
+# --------------------------------------------------------------------------- #
+def test_attach_windbg_and_cache(monkeypatch):
+    """
+    `handle_attach_windbg` should create exactly one session, store it under
+    the sentinel key, and return a banner mentioning the session_id.
+    """
+    monkeypatch.setattr(srv, "WinDbgSession", DummyWinDbgSession)
+
+    banner = srv.handle_attach_windbg(arguments={}, timeout=5, verbose=False)
+
+    # Banner contains the dummy session id
+    assert banner and "dummy-windbg-session" in banner[0].text
+
+    # Session is cached under the magic key
+    assert "__windbg_attach__" in srv.active_sessions
+    sess = srv.active_sessions["__windbg_attach__"]
+    assert isinstance(sess, DummyWinDbgSession)
+
+
+def test_run_command_after_attach(monkeypatch):
+    """
+    After attaching, running a command via the cached session should return
+    legitimate (non-empty) output and record the command.
+    """
+    monkeypatch.setattr(srv, "WinDbgSession", DummyWinDbgSession)
+
+    # First attach
+    srv.handle_attach_windbg(arguments={}, timeout=5, verbose=False)
+    sess = srv.active_sessions["__windbg_attach__"]
+
+    # Simulate what run_windbg_cmd does when dump_path is omitted
+    output = sess.send_command(".lastevent")
+
+    assert output == ["dummy-windbg-out for .lastevent"]
+    # Ensure the command was indeed recorded
+    assert ".lastevent" in sess.commands
+
+
+# ---------- optional live smoke-test (runs only when WinDbg is available) ---
+@pytest.mark.skipif(srv.AttachWindbgParams is None
+                    or
+                    'dbgx.shell.exe' not in map(lambda x: x.name().lower(), psutil.process_iter(['name'])),
+                    reason="Real WinDbg support not available on this machine or windbg not running for test")
+def test_attach_and_command_live():
+    """
+    This smoke-test attaches to a *real* WinDbg instance (if the JS plug-in
+    is already loaded and initialised) and runs a simple command to make
+    sure we get back some output.
+    """
+    banner = srv.handle_attach_windbg(arguments={}, timeout=10, verbose=False)
+    assert banner and "Attached to WinDbg session" in banner[0].text
+
+    # Use the cached live session
+    sess = srv.active_sessions["__windbg_attach__"]
+    out = sess.send_command(".lastevent")
+    print(out)
+    k_out = sess.send_command("k")
+    print(k_out)
+    assert len(k_out) > 0          # Should return at least one line of output

--- a/src/mcp_server_windbg/utils/windbg_mcp_plugin.js
+++ b/src/mcp_server_windbg/utils/windbg_mcp_plugin.js
@@ -1,0 +1,260 @@
+"use strict";
+/* -------------------------------------------------------- *
+ *  WinDbg MCP Plugin – file‑based IPC (TTD‑friendly)
+ *  DEBUG‑ENHANCED VERSION (2025‑07‑30)
+ * -------------------------------------------------------- */
+
+/* ---------- tiny logger ---------- */
+function dbg(msg) {
+    const ts = new Date().toISOString();
+    host.diagnostics.debugLog(`[MCP][${ts}] ${msg}\n`);
+}
+
+/* ---------- robust JSON helpers ---------- */
+function writeJson(path, obj) {
+    const fs = host.namespace.Debugger.Utility.FileSystem;
+    dbg(`writeJson → ${path}`);
+    let file;
+    try {
+        file = fs.CreateFile(path, "CreateAlways");
+        const writer = fs.CreateTextWriter(file, "Utf8");
+        writer.WriteLine(JSON.stringify(obj, null, 2));
+        dbg("writeJson ✔ done");
+    } catch (e) {
+        dbg(`writeJson ✖ ERROR: ${e.message}`);
+        throw e;
+    } finally {
+        if (file) file.Close();
+    }
+}
+
+function readFileText(reader) {
+    // Attempt ReadToEnd – fastest and safest when available
+    if (typeof reader.ReadToEnd === "function") {
+        try {
+            return reader.ReadToEnd();
+        } catch (_) {
+            // fall through to manual reading
+        }
+    }
+    // Manual line‑by‑line fallback – tolerate EOF exceptions
+    if (typeof reader.ReadLine === "function") {
+        let buf = "";
+        while (true) {
+            try {
+                const ln = reader.ReadLine();
+                if (ln === undefined || ln === null) break;
+                buf += ln;
+            } catch (e) {
+                // WinDbg throws "Cannot read past end of file" when EOF reached – treat as normal termination
+                if (e.message.includes("end of file")) break;
+                dbg(`readFileText ReadLine unexpected error: ${e.message}`);
+                break;
+            }
+        }
+        return buf;
+    }
+    // Iterator fallback (very old builds)
+    let buf = "";
+    try {
+        for (const ln of reader) buf += ln;
+    } catch (_) { /* swallow */ }
+    return buf;
+}
+
+
+function readJson(path) {
+    const fs = host.namespace.Debugger.Utility.FileSystem;
+    dbg(`readJson ← ${path}`);
+
+    if (!fs.FileExists(path)) {
+        dbg("readJson → file not found (return null)");
+        return null;
+    }
+
+    let file;
+    try {
+        file = fs.CreateFile(path, "OpenExisting");
+        const reader = fs.CreateTextReader(file, "Utf8");
+        const txt = readFileText(reader).trim();
+        if (!txt) {
+            dbg("readJson → empty file (return null)");
+            return null;
+        }
+        try {
+            const obj = JSON.parse(txt);
+            dbg("readJson ✔ parsed OK");
+            return obj;
+        } catch (e) {
+            dbg(`readJson ✖ JSON parse error: ${e.message}`);
+            return null;
+        }
+    } catch (e) {
+        dbg(`readJson ✖ ERROR: ${e.message}`);
+        return null;
+    } finally {
+        if (file) file.Close();
+    }
+}
+
+/* ---------- global state ---------- */
+let g = {
+    isInit: false,
+    sessionId: null,
+    commFile: null,
+    resultFile: null,
+    shutdownFile: null,
+    lastProcessedId: null,
+    monitorRunning: false
+};
+
+/* ---------- core ops ---------- */
+function generateSessionId() {
+    return `${Date.now()}_${Math.floor(Math.random() * 1e4)}`;
+}
+
+function executeDbg(cmd, id) {
+    const ctl = host.namespace.Debugger.Utility.Control;
+    dbg(`executeDbg: ${cmd}`);
+    const t0 = Date.now();
+    let out = [];
+    let ok = true,
+        err = null;
+
+    try {
+        for (const line of ctl.ExecuteCommand(cmd)) out.push(line.toString());
+    } catch (e) {
+        ok = false;
+        err = e.message;
+        out.push(`ERROR: ${e.message}`);
+        dbg(`executeDbg ✖ command failed: ${e.message}`);
+    }
+
+    const res = {
+        type: "result",
+        id: id ?? `cmd_${Date.now()}`,
+        command: cmd,
+        success: ok,
+        output: out,
+        error: err,
+        execMs: Date.now() - t0,
+        timestamp: Date.now(),
+        sessionId: g.sessionId
+    };
+
+    writeJson(g.resultFile, res);
+    dbg(`executeDbg ✔ wrote result (${res.execMs} ms)`);
+    return res;
+}
+
+/* ---------- command monitor ---------- */
+function pollOnce() {
+    const msg = readJson(g.commFile);
+    if (!msg) return;
+
+    dbg(`pollOnce: got message id=${msg.id}, type=${msg.type}`);
+
+    if (msg.type === "command" && msg.id !== g.lastProcessedId) {
+        g.lastProcessedId = msg.id;
+        executeDbg(msg.command, msg.id);
+    }
+}
+
+function monitorLoop(maxCycles = 2) {
+    if (g.monitorRunning) return;
+    g.monitorRunning = true;
+    const ctl = host.namespace.Debugger.Utility.Control;
+    dbg(`monitorLoop started, will run ${maxCycles} cycles …`);
+
+    let cycles = 0;
+    while (g.monitorRunning && cycles < maxCycles) {
+        try {
+            pollOnce();
+        } catch (e) {
+            dbg(`monitorLoop ✖ exception: ${e.message}`);
+        }
+        cycles++;
+        ctl.ExecuteCommand(".sleep 250");
+    }
+
+    g.monitorRunning = false;
+    dbg("monitorLoop exited.");
+}
+
+/* ---------- public commands ---------- */
+function mcp_init() {
+    dbg("mcp_init invoked");
+    if (g.isInit) return "Already initialised.";
+
+    g.sessionId = generateSessionId();
+    const tmp = "C:\\Temp";
+    g.commFile = `${tmp}\\windbg_mcp_${g.sessionId}.json`;
+    g.resultFile = `${tmp}\\windbg_mcp_${g.sessionId}_result.json`;
+    g.shutdownFile = `${tmp}\\windbg_mcp_${g.sessionId}_shutdown.json`;
+
+    writeJson(g.commFile, {
+        type: "init",
+        sessionId: g.sessionId,
+        status: "ready",
+        timestamp: Date.now()
+    });
+    g.isInit = true;
+
+    monitorLoop(1000);
+    return `MCP ready (session ${g.sessionId})`;
+}
+
+function mcp_status() {
+    dbg("mcp_status queried");
+    return {
+        sessionId: g.sessionId,
+        commFile: g.commFile,
+        resultFile: g.resultFile,
+        running: g.monitorRunning
+    };
+}
+
+function mcp_shutdown() {
+    dbg("mcp_shutdown invoked");
+    if (!g.isInit) return "Not initialised.";
+
+    writeJson(g.shutdownFile, {
+        type: "shutdown",
+        sessionId: g.sessionId,
+        timestamp: Date.now()
+    });
+    g.monitorRunning = false;
+    g.isInit = false;
+    dbg("mcp_shutdown ✔ complete");
+    return "MCP shut down.";
+}
+
+function mcp_exec(cmd) {
+    dbg(`mcp_exec: ${cmd}`);
+    if (!g.isInit) return "Init first.";
+    return executeDbg(cmd);
+}
+
+function mcp_check() {
+    dbg("mcp_check manual poke");
+    return pollOnce() ?? "No new command.";
+}
+
+/* ---------- script registration ---------- */
+function initializeScript() {
+    dbg("initializeScript – registering aliases");
+    return [
+        new host.functionAlias(mcp_init, "mcp_init"),
+        new host.functionAlias(mcp_status, "mcp_status"),
+        new host.functionAlias(mcp_shutdown, "mcp_shutdown"),
+        new host.functionAlias(mcp_exec, "mcp_exec"),
+        new host.functionAlias(mcp_check, "mcp_check")
+    ];
+}
+
+function invokeScript() {
+    dbg("WinDbg MCP plugin loaded.  !mcp_init to start.");
+    return initializeScript();
+}
+
+invokeScript();

--- a/src/mcp_server_windbg/windbg_session.py
+++ b/src/mcp_server_windbg/windbg_session.py
@@ -1,0 +1,500 @@
+import os
+import json
+import time
+import threading
+import glob
+from typing import List, Optional, Dict, Any
+from pathlib import Path
+import tempfile
+
+class WinDbgError(Exception):
+    """Custom exception for WinDbg-related errors"""
+    pass
+
+class WinDbgSession:
+    def __init__(
+        self,
+        dump_path: Optional[str] = None,
+        timeout: int = 30,
+        verbose: bool = False,
+        temp_dir: Optional[str] = None
+    ):
+        """
+        Initialize a new WinDbg session that communicates with the JavaScript plugin.
+
+        Args:
+            dump_path: Path to the crash dump file (optional for live debugging)
+            timeout: Timeout in seconds for waiting for WinDbg responses
+            verbose: Whether to print additional debug information
+            temp_dir: Custom temporary directory for communication files
+
+        Raises:
+            WinDbgError: If communication cannot be established
+        """
+        self.dump_path = dump_path
+        self.timeout = timeout
+        self.verbose = verbose
+        # Use C:\Temp to match the JavaScript plugin
+        self.temp_dir = temp_dir or "C:\\Temp"
+
+        # Communication state
+        self.session_id = None
+        self.comm_file = None
+        self.result_file = None
+        self.shutdown_file = None
+        self.is_connected = False
+        self.last_command_id = None
+
+        # Threading
+        self.lock = threading.Lock()
+        self.monitor_thread = None
+        self.stop_monitoring = False
+
+        # Ensure temp directory exists
+        os.makedirs(self.temp_dir, exist_ok=True)
+
+        # Try to find an existing WinDbg session
+        self._find_existing_session()
+
+    def _find_existing_session(self):
+        """Find an existing WinDbg MCP session"""
+        try:
+            # Look for communication files in temp directory
+            pattern = os.path.join(self.temp_dir, "windbg_mcp_*.json")
+            comm_files = glob.glob(pattern)
+
+            if comm_files:
+                # Filter out result and shutdown files
+                init_files = [f for f in comm_files if not f.endswith('_result.json') and not f.endswith('_shutdown.json')]
+
+                if init_files:
+                    # Use the most recent session
+                    init_files.sort(key=os.path.getmtime, reverse=True)
+                    self.comm_file = init_files[0]
+
+                    # Extract session ID from filename
+                    filename = os.path.basename(self.comm_file)
+                    self.session_id = filename.replace("windbg_mcp_", "").replace(".json", "")
+
+                    # Set up related files
+                    self.result_file = self.comm_file.replace('.json', '_result.json')
+                    self.shutdown_file = self.comm_file.replace('.json', '_shutdown.json')
+
+                    # Check if session is still active
+                    if self._check_session_active():
+                        self.is_connected = True
+                        if self.verbose:
+                            print(f"Connected to existing WinDbg session: {self.session_id}")
+                    else:
+                        if self.verbose:
+                            print(f"Found inactive session: {self.session_id}")
+
+        except Exception as e:
+            if self.verbose:
+                print(f"Error finding existing session: {e}")
+
+    def _check_session_active(self) -> bool:
+        """Check if the WinDbg session is still active"""
+        try:
+            if not self.comm_file or not os.path.exists(self.comm_file):
+                return False
+
+            # Read the communication file
+            with open(self.comm_file, 'r', encoding='utf-8') as f:
+                content = f.read().strip()
+
+            if not content:
+                if self.verbose:
+                    print("Communication file is empty")
+                return False
+
+            # Try to parse JSON (handle double-encoded JSON from JS plugin)
+            try:
+                data = json.loads(content)
+                # If the result is a string, it might be double-encoded JSON
+                if isinstance(data, str):
+                    try:
+                        data = json.loads(data)
+                    except json.JSONDecodeError:
+                        if self.verbose:
+                            print(f"Failed to parse double-encoded JSON: {data[:200]}...")
+                        return False
+            except json.JSONDecodeError as je:
+                if self.verbose:
+                    print(f"JSON decode error: {je}")
+                    print(f"File content: {content[:200]}...")
+                return False
+
+            # Ensure data is a dictionary
+            if not isinstance(data, dict):
+                if self.verbose:
+                    print(f"Expected dict, got {type(data)}: {data}")
+                return False
+
+            # Check if it's a recent init message
+            if data.get('type') == 'init' and data.get('status') == 'ready':
+                timestamp = data.get('timestamp', 0)
+                current_time = time.time() * 1000  # Convert to milliseconds
+
+                # Consider session active if init was within last 5 minutes
+                return (current_time - timestamp) < (5 * 60 * 1000)
+
+        except Exception as e:
+            if self.verbose:
+                print(f"Error checking session status: {e}")
+
+        return False
+
+    def wait_for_connection(self, timeout: Optional[int] = None) -> bool:
+        """
+        Wait for WinDbg to establish connection
+
+        Args:
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            True if connection established, False if timeout
+        """
+        wait_timeout = timeout or self.timeout
+        start_time = time.time()
+
+        while time.time() - start_time < wait_timeout:
+            self._find_existing_session()
+            if self.is_connected:
+                return True
+            time.sleep(0.5)
+
+        return False
+
+    def send_command(self, command: str, timeout: Optional[int] = None) -> List[str]:
+        """
+        Send a command to WinDbg and return the output
+
+        Args:
+            command: The WinDbg command to send
+            timeout: Custom timeout for this command
+
+        Returns:
+            List of output lines from WinDbg
+
+        Raises:
+            WinDbgError: If the command fails or times out
+        """
+        if not self.is_connected or not self.comm_file:
+            raise WinDbgError("Not connected to WinDbg. Make sure the JavaScript plugin is loaded and initialized with !mcp_init.")
+
+        cmd_timeout = timeout or self.timeout
+
+        with self.lock:
+            # Generate command ID
+            command_id = f"cmd_{int(time.time() * 1000)}_{os.getpid()}"
+            self.last_command_id = command_id
+
+            # Create command request
+            command_data = {
+                "type": "command",
+                "id": command_id,
+                "command": command,
+                "timestamp": int(time.time() * 1000),
+                "sessionId": self.session_id  # Match JS plugin field name
+            }
+
+            # Write command to communication file
+            try:
+                with open(self.comm_file, 'w') as f:
+                    json.dump(command_data, f, indent=2)
+
+                if self.verbose:
+                    print(f"Sent command: {command}")
+
+            except Exception as e:
+                raise WinDbgError(f"Failed to send command: {e}")
+
+            # Wait for result
+            return self._wait_for_result(command_id, cmd_timeout)
+
+    def _wait_for_result(self, command_id: str, timeout: int) -> List[str]:
+        """Wait for command result from WinDbg"""
+        if not self.result_file:
+            raise WinDbgError("Result file not configured")
+
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                if os.path.exists(self.result_file):
+                    with open(self.result_file, 'r', encoding='utf-8') as f:
+                        content = f.read().strip()
+
+                    if not content:
+                        time.sleep(0.1)
+                        continue
+
+                    try:
+                        result_data = json.loads(content)
+                    except json.JSONDecodeError:
+                        # Result file might be partially written, wait a bit more
+                        time.sleep(0.1)
+                        continue
+
+                    if not isinstance(result_data, dict):
+                        if self.verbose:
+                            print(f"Expected dict in result, got {type(result_data)}")
+                        time.sleep(0.1)
+                        continue
+
+                    # Check if this is the result we're waiting for
+                    if result_data.get('id') == command_id:
+                        # Clean up result file
+                        try:
+                            os.remove(self.result_file)
+                        except:
+                            pass
+
+                        if result_data.get('success', False):
+                            output = result_data.get('output', [])
+                            if self.verbose:
+                                print(f"Command completed in {result_data.get('executionTime', 0)}ms")
+                            return output
+                        else:
+                            error_msg = result_data.get('error', 'Unknown error')
+                            raise WinDbgError(f"Command failed: {error_msg}")
+
+            except Exception as e:
+                if self.verbose:
+                    print(f"Error reading result: {e}")
+
+            time.sleep(0.1)
+
+        raise WinDbgError(f"Command timed out after {timeout} seconds: {command_id}")
+
+    def get_session_info(self) -> Dict[str, Any]:
+        """Get information about the current session"""
+        return {
+            "session_id": self.session_id,
+            "is_connected": self.is_connected,
+            "dump_path": self.dump_path,
+            "comm_file": self.comm_file,
+            "result_file": self.result_file,
+            "timeout": self.timeout,
+            "temp_dir": self.temp_dir
+        }
+
+    def execute_analysis_commands(self) -> Dict[str, List[str]]:
+        """
+        Execute common analysis commands and return the results.
+
+        Returns a dictionary with the results of various analysis commands.
+        """
+        results = {}
+
+        try:
+            # Basic information
+            results["version"] = self.send_command("version")
+            results["target"] = self.send_command("vertarget")
+
+            # Last event and analysis
+            results["last_event"] = self.send_command("!analyze -v")
+
+            # Stack trace
+            results["stack_trace"] = self.send_command("k")
+
+            # Registers
+            results["registers"] = self.send_command("r")
+
+            # Modules
+            results["modules"] = self.send_command("lm")
+
+            # Threads
+            results["threads"] = self.send_command("~")
+
+            # Exception information
+            results["exception"] = self.send_command(".exr -1")
+
+        except WinDbgError as e:
+            if self.verbose:
+                print(f"Error during analysis: {e}")
+            results["error"] = str(e)
+
+        return results
+
+    def get_stack_trace(self) -> List[str]:
+        """Get the current stack trace"""
+        return self.send_command("k")
+
+    def get_registers(self) -> List[str]:
+        """Get current register values"""
+        return self.send_command("r")
+
+    def get_modules(self) -> List[str]:
+        """Get loaded modules"""
+        return self.send_command("lm")
+
+    def get_threads(self) -> List[str]:
+        """Get thread information"""
+        return self.send_command("~")
+
+    def analyze_crash(self) -> List[str]:
+        """Run crash analysis"""
+        return self.send_command("!analyze -v")
+
+    def get_exception_info(self) -> List[str]:
+        """Get exception information"""
+        return self.send_command(".exr -1")
+
+    def close(self):
+        """Close the WinDbg session"""
+        try:
+            if self.is_connected and self.shutdown_file:
+                # Signal shutdown to the JavaScript plugin
+                shutdown_data = {
+                    "type": "shutdown",
+                    "sessionId": self.session_id,
+                    "timestamp": int(time.time() * 1000)
+                }
+
+                with open(self.shutdown_file, 'w') as f:
+                    json.dump(shutdown_data, f, indent=2)
+
+            # Reset state
+            self.is_connected = False
+            self.session_id = None
+            self.comm_file = None
+            self.result_file = None
+            self.shutdown_file = None
+
+            if self.verbose:
+                print("WinDbg session closed")
+
+        except Exception as e:
+            if self.verbose:
+                print(f"Error closing session: {e}")
+
+    def shutdown(self):
+        """Alias for close() method for backward compatibility"""
+        self.close()
+
+    def __enter__(self):
+        """Context manager entry"""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit"""
+        self.close()
+
+    def list_available_sessions(self) -> List[Dict[str, Any]]:
+        """List all available WinDbg MCP sessions"""
+        sessions = []
+
+        try:
+            pattern = os.path.join(self.temp_dir, "windbg_mcp_*.json")
+            comm_files = glob.glob(pattern)
+
+            # Filter out result and shutdown files
+            init_files = [f for f in comm_files if not f.endswith('_result.json') and not f.endswith('_shutdown.json')]
+
+            for comm_file in init_files:
+                try:
+                    with open(comm_file, 'r', encoding='utf-8') as f:
+                        content = f.read().strip()
+
+                    if not content:
+                        continue
+
+                    try:
+                        data = json.loads(content)
+                        # Handle double-encoded JSON from JS plugin
+                        if isinstance(data, str):
+                            try:
+                                data = json.loads(data)
+                            except json.JSONDecodeError:
+                                if self.verbose:
+                                    print(f"Failed to parse double-encoded JSON in {comm_file}")
+                                continue
+                    except json.JSONDecodeError:
+                        if self.verbose:
+                            print(f"Invalid JSON in {comm_file}")
+                        continue
+
+                    if not isinstance(data, dict):
+                        if self.verbose:
+                            print(f"Expected dict in {comm_file}, got {type(data)}")
+                        continue
+
+                    if data.get('type') == 'init':
+                        filename = os.path.basename(comm_file)
+                        session_id = filename.replace("windbg_mcp_", "").replace(".json", "")
+
+                        sessions.append({
+                            "session_id": session_id,
+                            "comm_file": comm_file,
+                            "timestamp": data.get('timestamp', 0),
+                            "status": data.get('status', 'unknown'),
+                            "active": self._is_session_active(comm_file)
+                        })
+
+                except Exception as e:
+                    if self.verbose:
+                        print(f"Error reading session file {comm_file}: {e}")
+
+        except Exception as e:
+            if self.verbose:
+                print(f"Error listing sessions: {e}")
+
+        return sorted(sessions, key=lambda x: x['timestamp'], reverse=True)
+
+    def _is_session_active(self, comm_file: str) -> bool:
+        """Check if a specific session is active"""
+        try:
+            with open(comm_file, 'r', encoding='utf-8') as f:
+                content = f.read().strip()
+
+            if not content:
+                return False
+
+            try:
+                data = json.loads(content)
+                # Handle double-encoded JSON from JS plugin
+                if isinstance(data, str):
+                    try:
+                        data = json.loads(data)
+                    except json.JSONDecodeError:
+                        return False
+            except json.JSONDecodeError:
+                return False
+
+            if not isinstance(data, dict):
+                return False
+
+            if data.get('type') == 'init' and data.get('status') == 'ready':
+                timestamp = data.get('timestamp', 0)
+                current_time = time.time() * 1000
+                return (current_time - timestamp) < (5 * 60 * 1000)
+
+        except Exception:
+            pass
+
+        return False
+
+    def connect_to_session(self, session_id: str) -> bool:
+        """Connect to a specific session by ID"""
+        try:
+            comm_file = os.path.join(self.temp_dir, f"windbg_mcp_{session_id}.json")
+
+            if os.path.exists(comm_file):
+                self.session_id = session_id
+                self.comm_file = comm_file
+                self.result_file = comm_file.replace('.json', '_result.json')
+                self.shutdown_file = comm_file.replace('.json', '_shutdown.json')
+
+                if self._check_session_active():
+                    self.is_connected = True
+                    if self.verbose:
+                        print(f"Connected to session: {session_id}")
+                    return True
+
+        except Exception as e:
+            if self.verbose:
+                print(f"Error connecting to session {session_id}: {e}")
+
+        return False


### PR DESCRIPTION
I wanted to use this project to debug a TTD. I couldn't do it since cdb does not support TTD. 
I've added support for this by 'attaching' to a live windbg (preview) session. The attaching is done by running a .js script inside windbg that listens for files in c:\temp (This needs to be loaded manually by the user). The mcp server connects to such file using `attach_windbg` and create a new session `__windbg_attach__`
When the mcp receives a command (`run_windbg_cmd`) it writes the command to the file. The .js plugin reads the command, executes it and writes the output. This allows for a message loop. When we are done a shutdown file is written closing the windbg side.
We should note that there could be only one such windbg session currently.

I've also added additional test for the server, and the windbg component.