### PR TITLE
feat: add --filter-script for tool content text hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,13 @@ mcp-windbg/
 │   ├── __main__.py           # Module entry point
 │   ├── server.py             # MCP server implementation
 │   ├── cdb_session.py        # CDB/WinDbg session management
+│   ├── filter_script.py      # --filter-script loader and tool content hooks
 │   ├── prompts/              # Prompt templates for AI assistants
 │   │   └── dump-triage.prompt.md
 │   └── tests/                # Test suite
 │       ├── test_cdb.py       # Core CDB functionality tests
+│       ├── test_cli.py       # CLI argument wiring tests
+│       ├── test_filter_script.py  # Filter script hook tests
 │       ├── test_remote_debugging.py  # Remote debugging tests
 │       └── dumps/            # Test crash dump files (Git LFS)
 ├── scripts/                  # Utility scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-03-21
+
+### Added
+
+- **Tool Content Filter Script Hooks**: Added `--filter-script` so trusted Python helpers can rewrite string-valued tool arguments and tool text output for use cases like PII redaction without exposing full MCP protocol messages
+
 ## [0.13.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,9 +70,55 @@ Endpoint: `http://127.0.0.1:8000/mcp`
 --port PORT                              HTTP server port (default: 8000)
 --cdb-path PATH                          Custom path to cdb.exe
 --symbols-path PATH                      Custom symbols path
+--filter-script PATH                     Python script with process_input/process_output tool text hooks
 --timeout SECONDS                        Command timeout (default: 30)
 --verbose                                Enable verbose output
 ```
+
+### Filter Script Hooks
+
+Use `--filter-script` to load a small Python helper that can rewrite tool text only. The script never sees the full MCP JSON-RPC envelope, which keeps the hook surface smaller and avoids protocol interference.
+
+The script may define either or both of these functions:
+
+```python
+def process_input(text, context):
+    return text
+
+
+def process_output(text, context):
+    return text
+```
+
+- `process_input` is applied to string-valued tool arguments before the tool handler runs.
+- `process_output` is applied to `TextContent.text` values returned by tools before they go back to the client.
+- `text` is always a plain `str`.
+- `context` includes `hook`, `tool_name`, `transport`, and `call_id`.
+- Input callbacks also receive `argument_path` such as `$.command` or `$.payload.notes[0]`.
+- Output callbacks also receive `content_index` for the returned text item.
+- `call_id` is stable for the full lifetime of one tool invocation, so script writers can correlate input and output for the same call.
+- A hook may return `None` to leave the text unchanged, or return a replacement string.
+
+Example redaction filter:
+
+```python
+def process_input(text, context):
+    if context["tool_name"] == "run_windbg_cmd" and context["argument_path"] == "$.command":
+        return text.replace("user@example.com", "[redacted-email]")
+    return text
+
+
+def process_output(text, context):
+    return text.replace("user@example.com", "[redacted-email]")
+```
+
+Start the server with the filter enabled:
+
+```bash
+mcp-windbg --filter-script C:\filters\pii_redaction.py
+```
+
+The script runs in-process with the server. Treat it as trusted code.
 
 
 ## Configuration for Visual Studio Code
@@ -98,6 +144,12 @@ To make MCP servers available in all your workspaces, use the global user config
 ```
 
 This enables MCP Windbg in any workspace, without needing a local `.vscode/mcp.json` file.
+
+To enable a filter script, add it to the args:
+
+```json
+"args": ["-m", "mcp_windbg", "--filter-script", "C:\\filters\\pii_redaction.py"]
+```
 
 ### HTTP Transport Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-windbg"
-version = "0.13.0"
+version = "0.14.0"
 description = "A Model Context Protocol server providing tools to analyze Windows crash dumps using WinDbg/CDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/svnscha/mcp-windbg",
     "source": "github"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },
@@ -39,7 +39,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{port}/mcp"

--- a/src/mcp_windbg/__init__.py
+++ b/src/mcp_windbg/__init__.py
@@ -10,6 +10,7 @@ def main():
     )
     parser.add_argument("--cdb-path", type=str, help="Custom path to cdb.exe")
     parser.add_argument("--symbols-path", type=str, help="Custom symbols path")
+    parser.add_argument("--filter-script", type=str, help="Path to a Python script with process_input/process_output tool text hooks")
     parser.add_argument("--timeout", type=int, default=30, help="Command timeout in seconds")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
 
@@ -30,6 +31,7 @@ def main():
         asyncio.run(serve(
             cdb_path=args.cdb_path,
             symbols_path=args.symbols_path,
+            filter_script=args.filter_script,
             timeout=args.timeout,
             verbose=args.verbose
         ))
@@ -39,6 +41,7 @@ def main():
             port=args.port,
             cdb_path=args.cdb_path,
             symbols_path=args.symbols_path,
+            filter_script=args.filter_script,
             timeout=args.timeout,
             verbose=args.verbose
         ))

--- a/src/mcp_windbg/filter_script.py
+++ b/src/mcp_windbg/filter_script.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
+
+ResolvedCallback = Callable[[str, dict[str, Any]], str | None]
+
+
+def load_filter_script(script_path: str) -> "FilterScript":
+    path = Path(script_path).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"Filter script not found: {path}")
+
+    module_name = f"mcp_windbg_filter_{path.stem}_{abs(hash(str(path)))}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load filter script: {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    process_input = _resolve_callback(module, "process_input")
+    process_output = _resolve_callback(module, "process_output")
+
+    if process_input is None and process_output is None:
+        raise ValueError(
+            "Filter script must define process_input(text[, context]) and/or "
+            "process_output(text[, context])"
+        )
+
+    logger.info("Loaded tool content filter script from %s", path)
+
+    return FilterScript(
+        path=path,
+        process_input_callback=process_input,
+        process_output_callback=process_output,
+    )
+
+
+class FilterScript:
+    def __init__(
+        self,
+        path: Path,
+        process_input_callback: ResolvedCallback | None,
+        process_output_callback: ResolvedCallback | None,
+    ) -> None:
+        self.path = path
+        self._process_input_callback = process_input_callback
+        self._process_output_callback = process_output_callback
+
+    def process_input(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        transport: str,
+        call_id: str,
+    ) -> dict[str, Any] | None:
+        if self._process_input_callback is None:
+            return arguments
+
+        if arguments is None:
+            return None
+
+        return self._transform_value(
+            value=arguments,
+            callback=self._process_input_callback,
+            context={
+                "hook": "input",
+                "tool_name": tool_name,
+                "transport": transport,
+                "call_id": call_id,
+            },
+            path="$",
+        )
+
+    def process_output(
+        self,
+        tool_name: str,
+        content: list[Any],
+        transport: str,
+        call_id: str,
+    ) -> list[Any]:
+        if self._process_output_callback is None:
+            return content
+
+        transformed_content: list[Any] = []
+        for index, item in enumerate(content):
+            if isinstance(item, TextContent):
+                transformed_content.append(
+                    item.model_copy(
+                        update={
+                            "text": self._apply_callback(
+                                text=item.text,
+                                callback=self._process_output_callback,
+                                context={
+                                    "hook": "output",
+                                    "tool_name": tool_name,
+                                    "transport": transport,
+                                    "call_id": call_id,
+                                    "content_index": index,
+                                },
+                            )
+                        }
+                    )
+                )
+                continue
+
+            transformed_content.append(item)
+
+        return transformed_content
+
+    def _apply_callback(
+        self,
+        text: str,
+        callback: ResolvedCallback,
+        context: dict[str, Any],
+    ) -> str:
+        try:
+            transformed_text = callback(text, context)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Filter script {self.path} failed in {context['hook']} hook: {exc}"
+            ) from exc
+
+        if transformed_text is None:
+            return text
+
+        if not isinstance(transformed_text, str):
+            raise TypeError(
+                f"Filter script {self.path} {context['hook']} hook must return a string or None"
+            )
+
+        return transformed_text
+
+    def _transform_value(
+        self,
+        value: Any,
+        callback: ResolvedCallback,
+        context: dict[str, Any],
+        path: str,
+    ) -> Any:
+        if isinstance(value, str):
+            next_context = dict(context)
+            next_context["argument_path"] = path
+            return self._apply_callback(value, callback, next_context)
+
+        if isinstance(value, list):
+            return [
+                self._transform_value(
+                    value=item,
+                    callback=callback,
+                    context=context,
+                    path=f"{path}[{index}]",
+                )
+                for index, item in enumerate(value)
+            ]
+
+        if isinstance(value, dict):
+            return {
+                key: self._transform_value(
+                    value=item,
+                    callback=callback,
+                    context=context,
+                    path=f"{path}.{key}",
+                )
+                for key, item in value.items()
+            }
+
+        return value
+
+
+def _resolve_callback(module: Any, callback_name: str) -> ResolvedCallback | None:
+    callback = getattr(module, callback_name, None)
+    if callback is None:
+        return None
+    if not callable(callback):
+        raise TypeError(f"{callback_name} in filter script must be callable")
+
+    signature = inspect.signature(callback)
+    positional_parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    has_varargs = any(
+        parameter.kind == inspect.Parameter.VAR_POSITIONAL
+        for parameter in signature.parameters.values()
+    )
+
+    if len(positional_parameters) == 1 and not has_varargs:
+        return lambda text, context: callback(text)
+
+    if len(positional_parameters) >= 2 or has_varargs:
+        return lambda text, context: callback(text, context)
+
+    raise TypeError(
+        f"{callback_name} in filter script must accept text or text and context"
+    )

--- a/src/mcp_windbg/server.py
+++ b/src/mcp_windbg/server.py
@@ -3,10 +3,12 @@ import traceback
 import glob
 import winreg
 import logging
+import uuid
 from typing import Dict, Optional
 from contextlib import asynccontextmanager
 
 from .cdb_session import CDBSession, CDBError
+from .filter_script import FilterScript, load_filter_script
 from .prompts import load_prompt
 
 from mcp.shared.exceptions import McpError
@@ -208,6 +210,7 @@ def execute_common_analysis_commands(session: CDBSession) -> dict:
 async def serve(
     cdb_path: Optional[str] = None,
     symbols_path: Optional[str] = None,
+    filter_script: Optional[str] = None,
     timeout: int = 30,
     verbose: bool = False,
 ) -> None:
@@ -216,10 +219,12 @@ async def serve(
     Args:
         cdb_path: Optional custom path to cdb.exe
         symbols_path: Optional custom symbols path
+        filter_script: Optional Python script to filter tool content
         timeout: Command timeout in seconds
         verbose: Whether to enable verbose output
     """
-    server = _create_server(cdb_path, symbols_path, timeout, verbose)
+    content_filter = load_filter_script(filter_script) if filter_script else None
+    server = _create_server(cdb_path, symbols_path, timeout, verbose, content_filter, "stdio")
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
@@ -231,6 +236,7 @@ async def serve_http(
     port: int = 8000,
     cdb_path: Optional[str] = None,
     symbols_path: Optional[str] = None,
+    filter_script: Optional[str] = None,
     timeout: int = 30,
     verbose: bool = False,
 ) -> None:
@@ -241,6 +247,7 @@ async def serve_http(
         port: Port to bind the HTTP server to
         cdb_path: Optional custom path to cdb.exe
         symbols_path: Optional custom symbols path
+        filter_script: Optional Python script to filter tool content
         timeout: Command timeout in seconds
         verbose: Whether to enable verbose output
     """
@@ -249,7 +256,8 @@ async def serve_http(
     from starlette.types import Receive, Scope, Send
     import uvicorn
 
-    server = _create_server(cdb_path, symbols_path, timeout, verbose)
+    content_filter = load_filter_script(filter_script) if filter_script else None
+    server = _create_server(cdb_path, symbols_path, timeout, verbose, content_filter, "streamable-http")
 
     # Create the session manager
     session_manager = StreamableHTTPSessionManager(
@@ -288,6 +296,8 @@ def _create_server(
     symbols_path: Optional[str] = None,
     timeout: int = 30,
     verbose: bool = False,
+    content_filter: Optional[FilterScript] = None,
+    transport: str = "stdio",
 ) -> Server:
     """Create and configure the MCP server with all tools and prompts.
 
@@ -296,11 +306,25 @@ def _create_server(
         symbols_path: Optional custom symbols path
         timeout: Command timeout in seconds
         verbose: Whether to enable verbose output
+        content_filter: Optional filter for tool arguments and text output
+        transport: Transport label passed to the filter script context
 
     Returns:
         Configured Server instance
     """
     server = Server("mcp-windbg")
+
+    def filter_tool_arguments(tool_name: str, arguments: dict | None, call_id: str) -> dict:
+        if arguments is None:
+            arguments = {}
+        if content_filter is None:
+            return arguments
+        return content_filter.process_input(tool_name, arguments, transport, call_id) or {}
+
+    def filter_tool_content(tool_name: str, content: list[TextContent], call_id: str) -> list[TextContent]:
+        if content_filter is None:
+            return content
+        return content_filter.process_output(tool_name, content, transport, call_id)
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
@@ -366,6 +390,9 @@ def _create_server(
     @server.call_tool()
     async def call_tool(name, arguments: dict) -> list[TextContent]:
         try:
+            call_id = uuid.uuid4().hex
+            arguments = filter_tool_arguments(name, arguments, call_id)
+
             if name == "open_windbg_dump":
                 # Check if dump_path is missing or empty
                 if "dump_path" not in arguments or not arguments.get("dump_path"):
@@ -392,11 +419,11 @@ def _create_server(
 
                             dumps_found_text += "\nYou can analyze one of these dumps by specifying its path."
 
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"Please provide a path to a crash dump file to analyze.{dumps_found_text}\n\n"
                               f"You can use the 'list_windbg_dumps' tool to discover available crash dumps."
-                    )]
+                    )], call_id)
 
                 args = OpenWindbgDump(**arguments)
                 session = get_or_create_session(
@@ -425,7 +452,7 @@ def _create_server(
                     threads = session.send_command("~")
                     results.append("### Threads\n```\n" + "\n".join(threads) + "\n```\n\n")
 
-                return [TextContent(type="text", text="".join(results))]
+                return filter_tool_content(name, [TextContent(type="text", text="".join(results))], call_id)
 
             elif name == "open_windbg_remote":
                 args = OpenWindbgRemote(**arguments)
@@ -456,10 +483,10 @@ def _create_server(
                     threads = session.send_command("~")
                     results.append("### Threads\n```\n" + "\n".join(threads) + "\n```\n\n")
 
-                return [TextContent(
+                return filter_tool_content(name, [TextContent(
                     type="text",
                     text="".join(results)
-                )]
+                )], call_id)
 
             elif name == "run_windbg_cmd":
                 args = RunWindbgCmdParams(**arguments)
@@ -469,10 +496,10 @@ def _create_server(
                 )
                 output = session.send_command(args.command)
 
-                return [TextContent(
+                return filter_tool_content(name, [TextContent(
                     type="text",
                     text=f"Command: {args.command}\n\nOutput:\n```\n" + "\n".join(output) + "\n```"
-                )]
+                )], call_id)
 
             elif name == "send_ctrl_break":
                 args = SendCtrlBreakParams(**arguments)
@@ -482,38 +509,38 @@ def _create_server(
                 )
                 session.send_ctrl_break()
                 target = args.dump_path if args.dump_path else f"remote: {args.connection_string}"
-                return [TextContent(
+                return filter_tool_content(name, [TextContent(
                     type="text",
                     text=f"Sent CTRL+BREAK to CDB session ({target})."
-                )]
+                )], call_id)
 
             elif name == "close_windbg_dump":
                 args = CloseWindbgDumpParams(**arguments)
                 success = unload_session(dump_path=args.dump_path)
                 if success:
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"Successfully unloaded crash dump: {args.dump_path}"
-                    )]
+                    )], call_id)
                 else:
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"No active session found for crash dump: {args.dump_path}"
-                    )]
+                    )], call_id)
 
             elif name == "close_windbg_remote":
                 args = CloseWindbgRemoteParams(**arguments)
                 success = unload_session(connection_string=args.connection_string)
                 if success:
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"Successfully closed remote connection: {args.connection_string}"
-                    )]
+                    )], call_id)
                 else:
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"No active session found for remote connection: {args.connection_string}"
-                    )]
+                    )], call_id)
 
             elif name == "list_windbg_dumps":
                 args = ListWindbgDumpsParams(**arguments)
@@ -542,10 +569,10 @@ def _create_server(
                 dump_files.sort()
 
                 if not dump_files:
-                    return [TextContent(
+                    return filter_tool_content(name, [TextContent(
                         type="text",
                         text=f"No crash dump files (*.*dmp) found in {args.directory_path}"
-                    )]
+                    )], call_id)
 
                 # Format the results
                 result_text = f"Found {len(dump_files)} crash dump file(s) in {args.directory_path}:\n\n"
@@ -558,10 +585,10 @@ def _create_server(
 
                     result_text += f"{i+1}. {dump_file} ({size_mb} MB)\n"
 
-                return [TextContent(
+                return filter_tool_content(name, [TextContent(
                     type="text",
                     text=result_text
-                )]
+                )], call_id)
 
             raise McpError(ErrorData(
                 code=INVALID_PARAMS,

--- a/src/mcp_windbg/tests/test_cli.py
+++ b/src/mcp_windbg/tests/test_cli.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+
+import mcp_windbg
+
+
+def test_main_passes_filter_script_to_stdio(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_serve(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(mcp_windbg, "serve", fake_serve)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mcp-windbg", "--filter-script", "D:/filters/redact.py", "--transport", "stdio"],
+    )
+
+    mcp_windbg.main()
+
+    assert captured["filter_script"] == "D:/filters/redact.py"
+
+
+def test_main_passes_filter_script_to_http(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_serve_http(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(mcp_windbg, "serve_http", fake_serve_http)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mcp-windbg",
+            "--transport",
+            "streamable-http",
+            "--filter-script",
+            "D:/filters/redact.py",
+        ],
+    )
+
+    mcp_windbg.main()
+
+    assert captured["filter_script"] == "D:/filters/redact.py"

--- a/src/mcp_windbg/tests/test_filter_script.py
+++ b/src/mcp_windbg/tests/test_filter_script.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import pytest
+
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import TextContent
+
+import mcp_windbg.server as windbg_server
+
+from mcp_windbg.filter_script import load_filter_script
+
+
+def test_load_filter_script_requires_callback(tmp_path: Path):
+    """A script with neither process_input nor process_output is rejected."""
+    script_path = tmp_path / "empty_filter.py"
+    script_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="process_input"):
+        load_filter_script(str(script_path))
+
+
+def test_load_filter_script_file_not_found():
+    """A nonexistent path raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_filter_script("/nonexistent/path/filter.py")
+
+
+def test_filter_script_single_arg_callbacks(tmp_path: Path):
+    """Scripts with single-arg callbacks (no context) are supported."""
+    script_path = tmp_path / "simple_filter.py"
+    script_path.write_text(
+        "def process_output(text):\n"
+        "    return text.upper()\n",
+        encoding="utf-8",
+    )
+
+    fs = load_filter_script(str(script_path))
+    result = fs.process_output("run_windbg_cmd", [TextContent(type="text", text="hello")], "stdio", "id1")
+    assert result[0].text == "HELLO"
+
+
+def test_filter_script_output_only(tmp_path: Path):
+    """A script defining only process_output leaves input untouched."""
+    script_path = tmp_path / "output_only.py"
+    script_path.write_text(
+        "def process_output(text, context):\n"
+        "    return text + ' [redacted]'\n",
+        encoding="utf-8",
+    )
+
+    fs = load_filter_script(str(script_path))
+    # process_input should pass through unchanged
+    args = {"command": "k", "dump_path": "test.dmp"}
+    assert fs.process_input("run_windbg_cmd", args, "stdio", "id1") == args
+    # process_output should append
+    result = fs.process_output("run_windbg_cmd", [TextContent(type="text", text="stack")], "stdio", "id1")
+    assert result[0].text == "stack [redacted]"
+
+
+def test_filter_script_input_only(tmp_path: Path):
+    """A script defining only process_input leaves output untouched."""
+    script_path = tmp_path / "input_only.py"
+    script_path.write_text(
+        "def process_input(text, context):\n"
+        "    return text.replace('secret', '[REDACTED]')\n",
+        encoding="utf-8",
+    )
+
+    fs = load_filter_script(str(script_path))
+    args = {"command": "echo secret", "count": 42, "verbose": True}
+    result = fs.process_input("run_windbg_cmd", args, "stdio", "id1")
+    # String values are transformed, non-strings are preserved
+    assert result["command"] == "echo [REDACTED]"
+    assert result["count"] == 42
+    assert result["verbose"] is True
+    # process_output should pass through unchanged
+    content = [TextContent(type="text", text="original")]
+    assert fs.process_output("run_windbg_cmd", content, "stdio", "id1")[0].text == "original"
+
+
+def test_filter_script_callback_error(tmp_path: Path):
+    """A filter script that raises an exception produces a RuntimeError."""
+    script_path = tmp_path / "bad_filter.py"
+    script_path.write_text(
+        "def process_output(text, context):\n"
+        "    raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+
+    fs = load_filter_script(str(script_path))
+    with pytest.raises(RuntimeError, match="boom"):
+        fs.process_output("run_windbg_cmd", [TextContent(type="text", text="hi")], "stdio", "id1")
+
+
+def test_filter_script_rewrites_tool_content(tmp_path: Path, monkeypatch):
+    """End-to-end: filter rewrites tool args and output through a real MCP server."""
+    script_path = tmp_path / "redact_filter.py"
+    script_path.write_text(
+        "def process_input(text, context):\n"
+        "    global input_call_id\n"
+        "    input_call_id = context['call_id']\n"
+        "    if context['tool_name'] == 'run_windbg_cmd' and context['argument_path'] == '$.command':\n"
+        "        return text.replace('secret', '[redacted]')\n"
+        "    return text\n\n"
+        "def process_output(text, context):\n"
+        "    assert context['call_id'] == input_call_id\n"
+        "    if context['tool_name'] == 'run_windbg_cmd':\n"
+        "        return text + ' [filtered]'\n"
+        "    return text\n",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, str] = {}
+
+    class FakeSession:
+        def send_command(self, command: str) -> list[str]:
+            captured["command"] = command
+            return [f"processed {command}"]
+
+    monkeypatch.setattr(windbg_server, "get_or_create_session", lambda **kwargs: FakeSession())
+
+    content_filter = load_filter_script(str(script_path))
+    server = windbg_server._create_server(
+        timeout=30,
+        verbose=False,
+        content_filter=content_filter,
+        transport="memory",
+    )
+
+    async def run_test() -> None:
+        async with create_connected_server_and_client_session(server) as session:
+            result = await session.call_tool("run_windbg_cmd", {"dump_path": "demo.dmp", "command": "echo secret"})
+            assert result.isError is False
+            assert captured["command"] == "echo [redacted]"
+            assert isinstance(result.content[0], TextContent)
+            assert result.content[0].text == "Command: echo [redacted]\n\nOutput:\n```\nprocessed echo [redacted]\n``` [filtered]"
+
+    anyio.run(run_test)


### PR DESCRIPTION
Add a --filter-script CLI option that loads a trusted Python helper to rewrite string-valued tool arguments (input) and TextContent.text values (output) without exposing the full MCP JSON-RPC envelope.

- New filter_script.py module with loader, arity detection, and recursive argument walker with JSONPath-like paths
- Each tool invocation gets a stable call_id for input/output correlation
- Supports both stdio and streamable-http transports
- Includes 9 tests (unit + end-to-end MCP integration + CLI wiring)
- Updated README with API docs and examples
- Updated CHANGELOG and AGENTS.md