### PR TITLE
fix: fill in pip/PyPI package metadata (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Package metadata**: Filled in distribution metadata so `pip show` / PyPI are complete — added the author/maintainer email, project URLs (Homepage, Repository, Issues, Changelog), and classifiers for Windows, console environment, and the Debuggers/QA topics (#36)
+
 ### Fixed
 
 - **Stdio server resilience**: The stdio transport no longer crashes on a malformed input line. `serve()` now uses the SDK default `raise_exceptions=False`, so an unparseable line (e.g. when the server is run directly in a terminal) is logged instead of tearing down the whole process (#45)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,17 @@ version = "0.14.0"
 description = "A Model Context Protocol server providing tools to analyze Windows crash dumps using WinDbg/CDB"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "svnscha" }]
+authors = [{ name = "svnscha", email = "sven.scharmentke@gmail.com" }]
+maintainers = [{ name = "svnscha", email = "sven.scharmentke@gmail.com" }]
 keywords = ["windbg", "cdb", "mcp", "llm", "crash-analysis"]
 license = "MIT"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "Environment :: Console",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Software Development :: Debuggers",
+    "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -23,6 +28,12 @@ dependencies = [
     "starlette>=0.52.1",
     "uvicorn>=0.42.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/svnscha/mcp-windbg"
+Repository = "https://github.com/svnscha/mcp-windbg"
+Issues = "https://github.com/svnscha/mcp-windbg/issues"
+Changelog = "https://github.com/svnscha/mcp-windbg/blob/main/CHANGELOG.md"
 
 [project.scripts]
 mcp-windbg = "mcp_windbg:main"


### PR DESCRIPTION
## Summary

Fixes #36. `pip show mcp-windbg` had an empty **Home-page** and **Author-email**. This fills in the distribution metadata in `pyproject.toml`.

## Changes

- **Author/maintainer email** — `authors`/`maintainers` now include `sven.scharmentke@gmail.com`, so `Author-email` / `Maintainer-email` are populated.
- **`[project.urls]`** — added `Homepage`, `Repository`, `Issues`, `Changelog`. This is what populates the project links (the old "Home-page" gap) on PyPI.
- **Classifiers** — added `Environment :: Console`, `Operating System :: Microsoft :: Windows` (this is a Windows-only tool), and `Topic :: Software Development :: Debuggers` / `Quality Assurance` for discoverability.

License already uses the modern SPDX `License-Expression: MIT`, so no license classifier was added (that combination is disallowed).

## Verification

Built locally and inspected the generated `METADATA`:

```
Author-email: svnscha <sven.scharmentke@gmail.com>
Maintainer-email: svnscha <sven.scharmentke@gmail.com>
License-Expression: MIT
Project-URL: Homepage, https://github.com/svnscha/mcp-windbg
Project-URL: Repository, https://github.com/svnscha/mcp-windbg
Project-URL: Issues, https://github.com/svnscha/mcp-windbg/issues
Project-URL: Changelog, https://github.com/svnscha/mcp-windbg/blob/main/CHANGELOG.md
Classifier: Environment :: Console
Classifier: Operating System :: Microsoft :: Windows
Classifier: Topic :: Software Development :: Debuggers
...
```

- [x] `python -m build` (sdist + wheel) succeeds
- [x] `twine check dist/*` — both PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
