### PR TITLE
deps(docs): consolidate docs tooling bumps (#51, #52, #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Package metadata**: Filled in distribution metadata so `pip show` / PyPI are complete - added the author/maintainer email, project URLs (Homepage, Repository, Issues, Changelog), and classifiers for Windows, console environment, and the Debuggers/QA topics (#36)
 - **Contributor guide**: Migrated `AGENTS.md` to `CLAUDE.md` and added `.claude/rules/` (Markdown typography and documentation authoring), plus `scripts/Format-Docs.ps1` to enforce the typography rules
+- **Docs tooling**: Bumped the docs build dependencies in `requirements-docs.txt` to their latest patch floors - `mkdocs>=1.6.1`, `mkdocs-material>=9.7.6`, `pymdown-extensions>=10.21.3` (consolidates #51, #52, #53)
 
 ### Fixed
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,6 +3,6 @@
 #   python -m mkdocs serve      # live preview at http://127.0.0.1:8000
 #   python -m mkdocs build      # render static site into ./site
 # Mermaid diagrams use a small self-contained loader (docs/assets/mermaid.js).
-mkdocs>=1.6
-mkdocs-material>=9.7
-pymdown-extensions>=10.21
+mkdocs>=1.6.1
+mkdocs-material>=9.7.6
+pymdown-extensions>=10.21.3


### PR DESCRIPTION
## Summary

Consolidates the three open Dependabot patch bumps for the MkDocs docs toolchain into a single change to `requirements-docs.txt`:

| Package | Before | After |
| --- | --- | --- |
| `mkdocs` | `>=1.6` | `>=1.6.1` |
| `mkdocs-material` | `>=9.7` | `>=9.7.6` |
| `pymdown-extensions` | `>=10.21` | `>=10.21.3` |

These are lower-bound (floor) bumps only, scoped to the docs build dependencies; runtime/package dependencies are untouched.

## Verification

- Installed the bumped requirements and ran `python -m mkdocs build --strict` - the site builds with no errors or broken links.
- `pwsh scripts/Format-Docs.ps1 -Check` passes (CHANGELOG edit).

## Replaces

Supersedes and closes:

- #51 (mkdocs-material)
- #52 (pymdown-extensions)
- #53 (mkdocs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
