### PR TITLE
ci(deps): collapse Dependabot into one grouped PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Python dependencies from pyproject.toml
+  # Python dependencies (pyproject.toml and requirements-docs.txt)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -17,13 +17,12 @@ updates:
     commit-message:
       prefix: "deps(python)"
     groups:
-      # Group minor/patch updates together to reduce noise
-      python-minor:
+      # One PR for every pip update across all manifests in this directory
+      # (pyproject.toml and requirements-docs.txt). Omitting update-types means
+      # major bumps join the group too, instead of each opening its own PR.
+      python:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   # GitHub Actions workflow dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Stops Dependabot from opening a flurry of separate dependency PRs. The pip group was scoped to `update-types: [minor, patch]`, which meant any update Dependabot didn't classify into that set dropped out of the group and got its own PR. That is exactly what produced the three docs-tooling PRs (#51, #52, #53), and it would also split off every major-version bump.

This removes the `update-types` filter so the `*` pattern groups **all packages and all bump types** into one PR.

## Behavior after this change

- **pip**: one grouped PR per weekly run, covering both `pyproject.toml` and `requirements-docs.txt`.
- **github-actions**: one grouped PR per weekly run (already configured this way).

## Note on scope

Dependabot cannot combine different ecosystems into a single PR, so the realistic minimum is one PR per ecosystem (pip + github-actions). A grouped PR also means a breaking major bump rides along with everything else; if that ever blocks the group, we can split majors back out with a dedicated `update-types: [major]` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
