### PR TITLE
release: 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.0] - 2026-06-08
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-windbg"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Model Context Protocol server providing tools to analyze Windows crash dumps using WinDbg/CDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/svnscha/mcp-windbg",
     "source": "github"
   },
-  "version": "0.14.0",
+  "version": "0.15.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "transport": {
         "type": "stdio"
       },
@@ -39,7 +39,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "mcp-windbg"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary

Release prep for **0.15.0**. Bumps the version in `pyproject.toml`, `server.json` (top-level and
both package entries), and `uv.lock`, and dates the `0.15.0` CHANGELOG section.

## Changes since 0.14.0 (from the CHANGELOG)

- **Added**: MkDocs user guide and GitHub Pages deploy; `dump-triage` prompt reference; usage-guide
  pages for HTTP hosting, redaction, and WER capture.
- **Changed**: declarative end-to-end test suite with subprocess coverage; package metadata;
  contributor guide and `.claude/rules/`; docs-tooling floors; LFS dumps mandatory in tests.
- **Removed**: three unused functions (`execute_common_analysis_commands`,
  `CDBSession.get_session_id`, `prompts.get_available_prompts`).
- **Fixed**: stdio server no longer crashes on a malformed input line (#45).

## Verification

- `scripts/check-version-consistency.ps1` - all versions consistent at 0.15.0.
- `scripts/validate-server-schema.py` - `server.json` valid against the MCP schema.
- `scripts/Format-Docs.ps1 -Check` - clean.
- `uv run pytest src/mcp_windbg/tests/` - 27 passed.
- `uv build` + `uv run twine check dist/*` - both artifacts PASSED.

## Releasing

After this merges to `main`, tag `v0.15.0` on the merge commit and push it. `publish-mcp.yml`
runs the consistency check, tests, build, publishes to PyPI, and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
