### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Docs**: Added a Claude Code client guide (`claude mcp add` with both `uvx` and `python -m mcp_windbg`) to `docs/reference/clients.md`, and simplified the README configuration section to lead with the VS Code and Claude Code setups and link the docs for the rest.
+- **Docs**: Documented Autohand Code as an MCP client in `docs/reference/clients.md` (`autohand mcp add` with `--scope project`), noting that the server inherits `_NT_SYMBOL_PATH` from the launching environment since Autohand has no per-server env flag (#63).
 
 ## [0.15.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ The script defines `process_input` and/or `process_output` callbacks and runs in
 claude mcp add mcp-windbg -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- python -m mcp_windbg
 ```
 
+**Autohand Code** - register the installed stdio server from the command line:
+
+```bash
+autohand mcp add mcp-windbg python -m mcp_windbg
+```
+
+The server inherits `_NT_SYMBOL_PATH` from the environment that launches [Autohand Code](https://github.com/autohandai/code-cli/). Add `--scope project` after `mcp add` to keep the registration in the current workspace.
+
 Prefer not to install the package? Replace `python -m mcp_windbg` with `uvx --from git+https://github.com/svnscha/mcp-windbg mcp-windbg` in either setup to fetch and run the server on demand.
 
 Once configured, restart your MCP client and start debugging:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The script defines `process_input` and/or `process_output` callbacks and runs in
 
 ## Configuration
 
-`mcp-windbg` works with any MCP client. Two common setups are below; see the [client configuration guide](https://svnscha.github.io/mcp-windbg/reference/clients/) for Claude Desktop, Copilot CLI, HTTP, and from-source.
+`mcp-windbg` works with any MCP client. Two common setups are below; see the [client configuration guide](https://svnscha.github.io/mcp-windbg/reference/clients/) for Claude Desktop, Copilot CLI, Autohand Code, HTTP, and from-source.
 
 **VS Code (GitHub Copilot)** - press `F1` and select **MCP: Open User Configuration** to enable it in every workspace:
 
@@ -118,14 +118,6 @@ The script defines `process_input` and/or `process_output` callbacks and runs in
 ```bash
 claude mcp add mcp-windbg -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- python -m mcp_windbg
 ```
-
-**Autohand Code** - register the installed stdio server from the command line:
-
-```bash
-autohand mcp add mcp-windbg python -m mcp_windbg
-```
-
-The server inherits `_NT_SYMBOL_PATH` from the environment that launches [Autohand Code](https://github.com/autohandai/code-cli/). Add `--scope project` after `mcp add` to keep the registration in the current workspace.
 
 Prefer not to install the package? Replace `python -m mcp_windbg` with `uvx --from git+https://github.com/svnscha/mcp-windbg mcp-windbg` in either setup to fetch and run the server on demand.
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -106,6 +106,21 @@ Add server options such as a [filter script](../scenarios/redaction.md) after th
 for example `-- python -m mcp_windbg --filter-script C:\filters\pii_redaction.py`. Run
 `claude mcp list` to confirm it connected.
 
+## Autohand Code
+
+[Autohand Code](https://github.com/autohandai/code-cli) registers stdio servers with
+`autohand mcp add <name> <command>`. Add `--scope project` to keep the registration in the
+current workspace instead of the user profile:
+
+```bash
+autohand mcp add mcp-windbg uvx --from git+https://github.com/svnscha/mcp-windbg mcp-windbg
+```
+
+Autohand has no flag for a per-server `_NT_SYMBOL_PATH`; the server inherits the environment
+that launched Autohand. Set `_NT_SYMBOL_PATH` in that shell (or system-wide) before starting
+Autohand so stack traces resolve. If you installed the package with pip or from source,
+replace the `uvx ...` command with `python -m mcp_windbg`.
+
 ## GitHub Copilot CLI
 
 Edit `C:\Users\{username}\.copilot\mcp-config.json`:


### PR DESCRIPTION
## Summary

Add an Autohand Code command beside the existing Claude Code registration. The note explains that the server inherits `_NT_SYMBOL_PATH` from the environment that launches Autohand.

## Verification

- `git diff --check`
- `uv run pytest` cannot collect on macOS because the Windows-only server imports `winreg`; Windows CI remains the appropriate runtime check