### PR TITLE
Consolidate dependency updates (2 PRs)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ fromJson(inputs.python-versions) }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         lfs: true
 
@@ -76,7 +76,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         lfs: true
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,4 +5,4 @@
 # Mermaid diagrams use a small self-contained loader (docs/assets/mermaid.js).
 mkdocs>=1.6.1
 mkdocs-material>=9.7.6
-pymdown-extensions>=10.21.3
+pymdown-extensions>=11.0


### PR DESCRIPTION
Consolidates the following Dependabot PRs into a single update:

- #60 — ci(deps): bump actions/checkout from 6 to 7 in the actions group
- #61 — deps(python): update pymdown-extensions requirement from >=10.21.3 to >=11.0 in the python group

Supersedes #60
Supersedes #61

No lock file to regenerate: the actions bump only edits workflow YAML, and pymdown-extensions is a `>=` pin in requirements-docs.txt (not tracked by uv.lock/pyproject.toml). The two changes touch disjoint files and merged without conflicts.