### PR TITLE
docs: add a development page (run from a local checkout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs**: Documented Autohand Code as an MCP client in `docs/reference/clients.md` (`autohand mcp add` with `--scope project`), noting that the server inherits `_NT_SYMBOL_PATH` from the launching environment since Autohand has no per-server env flag (#63).
 - **Dependencies**: Refreshed the runtime dependency floors to their latest releases - `mcp>=1.28.1`, `pydantic>=2.13.4`, `starlette>=1.3.1` (0.x to 1.x), `uvicorn>=0.51.0` - and the test tooling floor `pytest>=9.1.1`, and regenerated `uv.lock`. The streamable-http transport was smoke-tested against the Starlette 1.x major bump.
 - **Docs**: Switched the README Star History chart to the sealed-token star-history.com embed with light and dark variants.
+- **Docs**: Added a Development page (`docs/development.md`) covering the editable user-mode install (`pip install --user -e .`), the `uv` alternative, building a wheel, and pointing Claude Code / Claude Desktop / VS Code at the local dev build.
 
 ## [0.15.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The beauty of MCP is that you write the server once, and it works everywhere. Ch
 | **[Tools Reference](https://svnscha.github.io/mcp-windbg/reference/tools/)** | The MCP tools and their parameters |
 | **[Client configuration](https://svnscha.github.io/mcp-windbg/reference/clients/)** | VS Code, Claude Desktop, Copilot CLI, pip, and source |
 | **[Troubleshooting](https://svnscha.github.io/mcp-windbg/troubleshooting/)** | Common issues and solutions |
+| **[Development](https://svnscha.github.io/mcp-windbg/development/)** | Run from a local checkout and point a client at the dev build |
 
 ## Examples
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,111 @@
+# Development
+
+Run `mcp-windbg` from a local checkout so an MCP client uses your working tree, with source
+edits picked up live. This is the setup for working on the server itself.
+
+## Editable install
+
+An editable install links the package to your checkout instead of copying it, so changes to
+the source (and switching branches) take effect the next time the server starts. Install into
+your user site with pip:
+
+```powershell
+git clone https://github.com/svnscha/mcp-windbg.git
+cd mcp-windbg
+python -m pip install --user -e .
+```
+
+This puts `mcp-windbg.exe` in your user scripts directory (for example
+`%APPDATA%\Python\Python314\Scripts`). That directory is often not on `PATH`, which is fine:
+the client configs below launch the module with a full Python path instead, so `PATH` does
+not matter.
+
+Confirm the install points at your checkout:
+
+```powershell
+python -c "import mcp_windbg, inspect; print(inspect.getfile(mcp_windbg))"
+```
+
+It should print the path inside your clone (`...\mcp-windbg\src\mcp_windbg\__init__.py`).
+
+!!! tip "uv alternative"
+    `uv sync --dev` already installs the project editable into `.venv`, so `uv run mcp-windbg`
+    runs your checkout without a separate install. Use that for running the tests; use the
+    `--user` install above when you want an MCP client to launch the dev build directly.
+
+## Point an MCP client at the dev build
+
+Use a distinct server name (for example `mcp-windbg-dev`) so it does not clash with a released
+install, and launch the module with your full Python path so the editable install resolves
+regardless of `PATH`. Add `--verbose` to see the debugger commands the server runs.
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add mcp-windbg-dev -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- C:\Python314\python.exe -m mcp_windbg --verbose
+    ```
+
+=== "Claude Desktop"
+
+    Edit `%APPDATA%\Claude\claude_desktop_config.json`:
+
+    ```json title="claude_desktop_config.json"
+    {
+        "mcpServers": {
+            "mcp-windbg-dev": {
+                "command": "C:\\Python314\\python.exe",
+                "args": ["-m", "mcp_windbg", "--verbose"],
+                "env": {
+                    "_NT_SYMBOL_PATH": "SRV*C:\\Symbols*https://msdl.microsoft.com/download/symbols"
+                }
+            }
+        }
+    }
+    ```
+
+=== "VS Code (GitHub Copilot)"
+
+    Edit `.vscode/mcp.json`:
+
+    ```json title=".vscode/mcp.json"
+    {
+        "servers": {
+            "mcp_windbg_dev": {
+                "type": "stdio",
+                "command": "C:\\Python314\\python.exe",
+                "args": ["-m", "mcp_windbg", "--verbose"],
+                "env": {
+                    "_NT_SYMBOL_PATH": "SRV*C:\\Symbols*https://msdl.microsoft.com/download/symbols"
+                }
+            }
+        }
+    }
+    ```
+
+Replace `C:\Python314\python.exe` with the interpreter you ran `pip install --user` against
+(`python -c "import sys; print(sys.executable)"`). Restart the MCP client after editing source
+or switching branches so it relaunches the server on the new code.
+
+## Build a wheel
+
+To produce the distributable artifacts (a wheel and an sdist under `dist/`), for example to
+test packaging before a release:
+
+```powershell
+uv build
+```
+
+This is a built artifact, not an editable install: reinstall it to pick up later source
+changes. For day-to-day development, prefer the editable install above.
+
+## Tests
+
+```powershell
+uv run pytest src/mcp_windbg/tests/ -v                 # full suite (needs cdb.exe for live cases)
+uv run pytest src/mcp_windbg/tests/ -v -m "not live"   # hermetic subset, no debugger needed
+```
+
+See the [end-to-end scenario guide](https://github.com/svnscha/mcp-windbg/blob/main/src/mcp_windbg/tests/e2e/README.md)
+for the test format, and
+[manual feature verification](https://github.com/svnscha/mcp-windbg/blob/main/src/mcp_windbg/tests/e2e/manual-verification.md)
+for driving each debugging mode against a real target.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Prompts: reference/prompts.md
       - Client configuration: reference/clients.md
   - Troubleshooting: troubleshooting.md
+  - Development: development.md
 
 plugins:
   - search


### PR DESCRIPTION
Adds `docs/development.md` documenting how to run `mcp-windbg` from a local checkout for development, and links it from the README and nav.

Covers:
- **Editable user-mode install** - `python -m pip install --user -e .`, so an MCP client uses your working tree and source edits / branch switches take effect on the next server start. Includes a check that the install resolves to the checkout.
- **uv alternative** - `uv sync --dev` already installs the project editable into `.venv`.
- **Configuring a client for the dev build** - Claude Code, Claude Desktop, and VS Code snippets that launch `python -m mcp_windbg` with a full Python path (so the user-scripts dir not being on `PATH` does not matter) and a distinct `mcp-windbg-dev` name.
- **Building a wheel** - `uv build`, with a note that it is a built artifact, not editable.
- **Tests** - pointers to the e2e scenario guide and the manual verification checklist.

Verified locally: `mkdocs build --strict` clean, markdown typography clean.