### PR TITLE
Fix go-command target freezing on com pipes, add pipe banner detection and adds wait_for_break command

### DIFF
--- a/src/mcp_windbg/debug_session.py
+++ b/src/mcp_windbg/debug_session.py
@@ -122,6 +122,7 @@ class DebuggerSession:
         self.ready_event = threading.Event()
         self._marker_seq = 0
         self._expected_marker: Optional[str] = None
+        self._target_running = False
 
         try:
             creationflags = 0
@@ -207,6 +208,14 @@ class DebuggerSession:
         if not self.ready_event.wait(timeout or self.timeout):
             raise DebuggerError("Timed out waiting for debugger prompt")
 
+    _GO_COMMANDS = frozenset({"g", "gh", "gn", "gN", "gu", "gc", "p", "t", "pa", "ta"})
+
+    @staticmethod
+    def _is_go_command(command: str) -> bool:
+        """Return True if *command* resumes the target (fire-and-forget)."""
+        token = command.strip().split()[0] if command.strip() else ""
+        return token in DebuggerSession._GO_COMMANDS
+
     def send_command(self, command: str, timeout: Optional[int] = None) -> List[str]:
         """Send a command and return its output lines.
 
@@ -214,12 +223,28 @@ class DebuggerSession:
         CTRL+BREAK and the session is resynchronized before the timeout is
         reported, so the next command starts from a clean prompt.
 
+        Go-class commands (``g``, ``gh``, ``gn``, ...) are fire-and-forget:
+        they resume the target and no prompt arrives until the next break, so
+        we write them without a marker and return immediately.
+
         Raises:
             DebuggerError: if the process is gone, I/O fails, or the command
                 times out.
         """
         if not self.process:
             raise DebuggerError("Debugger process is not running")
+
+        if self._is_go_command(command):
+            try:
+                self.process.stdin.write(f"{command}\n")
+                self.process.stdin.flush()
+            except (IOError, ValueError) as e:
+                raise DebuggerError(f"Failed to send command: {e}")
+            self._target_running = True
+            return ["Target resumed."]
+
+        if self._target_running and self.is_live_session:
+            self._break_in_and_resync()
 
         marker = self._next_marker()
         self.ready_event.clear()
@@ -266,6 +291,58 @@ class DebuggerSession:
             self._expected_marker = None
         return resynced
 
+    def _break_in_and_resync(self) -> None:
+        """Break into a running target and wait for the prompt before sending
+        the next command.  Called automatically when a regular command is issued
+        while ``_target_running`` is set."""
+        try:
+            self.process.send_signal(signal.CTRL_BREAK_EVENT)
+        except Exception as e:
+            raise DebuggerError(f"Failed to break into running target: {e}")
+        try:
+            self._wait_for_prompt(min(10, max(3, self.timeout)))
+        except DebuggerError:
+            pass
+        self._target_running = False
+
+    def wait_for_break(self, timeout: Optional[int] = None) -> List[str]:
+        """Block until the target breaks in (crash, breakpoint, or manual break).
+
+        Queues a marker into kd's stdin.  While the target runs freely kd
+        cannot process it, so the marker sits until the target stops.  When
+        the target eventually halts (BSOD, breakpoint, CTRL+BREAK), kd
+        processes the queued marker and this method returns all output
+        collected in between — typically the crash banner or break-in message.
+        """
+        if not self.process:
+            raise DebuggerError("Debugger process is not running")
+        if not self._target_running:
+            return ["Target is not running."]
+
+        marker = self._next_marker()
+        self.ready_event.clear()
+        with self.lock:
+            self.output_lines = []
+            self._expected_marker = marker
+
+        try:
+            self.process.stdin.write(f".echo {marker}\n")
+            self.process.stdin.flush()
+        except (IOError, ValueError) as e:
+            raise DebuggerError(f"Failed to queue marker: {e}")
+
+        wait = timeout or 300
+        if not self.ready_event.wait(wait):
+            raise DebuggerError(
+                f"Target did not break within {wait} seconds"
+            )
+
+        self._target_running = False
+        with self.lock:
+            result = self.output_lines.copy()
+            self.output_lines = []
+        return result
+
     def send_ctrl_break(self) -> None:
         """Deliver CTRL+BREAK to break into a running target.
 
@@ -278,6 +355,7 @@ class DebuggerSession:
             self.process.send_signal(signal.CTRL_BREAK_EVENT)
         except Exception as e:
             raise DebuggerError(f"Failed to send CTRL+BREAK: {e}")
+        self._target_running = False
 
     # -- Teardown ---------------------------------------------------------
 

--- a/src/mcp_windbg/kd_session.py
+++ b/src/mcp_windbg/kd_session.py
@@ -33,10 +33,13 @@ from .debug_session import (
 # Raised for kernel session failures.
 KDError = DebuggerError
 
-# The banner ``kd`` prints once the kernel link is up (KDNET or COM). Matched as
-# a substring; the full line is e.g.
-#   "Connected to target 172.16.2.189 on port 50005 on local IP 172.16.2.183."
-KERNEL_CONNECTED_BANNER = "Connected to target"
+# Banners ``kd`` prints once the kernel link is up. KDNET says
+# "Connected to target ...", while pipe/COM/serial says
+# "Kernel Debugger connection established". Matched as substrings.
+KERNEL_CONNECTED_BANNERS = [
+    "Connected to target",
+    "Kernel Debugger connection established",
+]
 
 # Default paths where kd.exe (kernel debugger) might be located.
 DEFAULT_KD_PATHS = [
@@ -114,7 +117,7 @@ class KDSession(DebuggerSession):
 
     def _on_output_line(self, line: str) -> None:
         """Notice the connect banner (called under the reader lock)."""
-        if KERNEL_CONNECTED_BANNER in line:
+        if any(banner in line for banner in KERNEL_CONNECTED_BANNERS):
             self._connected_event.set()
 
     def _startup(self) -> None:

--- a/src/mcp_windbg/server.py
+++ b/src/mcp_windbg/server.py
@@ -202,6 +202,12 @@ class SendCtrlBreak(BaseModel):
     session_id: str = Field(description="A live session_id (cdb remote or kd) to break into.")
 
 
+class WaitForBreak(BaseModel):
+    """Parameters for waiting until the target breaks in."""
+    session_id: str = Field(description="A kd session_id to wait on.")
+    timeout_seconds: Optional[int] = Field(default=300, description="Maximum seconds to wait (default 300). The target may break due to a crash, breakpoint, or manual CTRL+BREAK.")
+
+
 def _combine_symbols(per_call: Optional[str], server_default: Optional[str]) -> Optional[str]:
     """Combine per-call and server-default symbol paths."""
     if per_call and server_default:
@@ -399,6 +405,15 @@ def _create_server(
                 """,
                 inputSchema=SendCtrlBreak.model_json_schema(),
             ),
+            Tool(
+                name="wait_for_break",
+                description="""
+                Block until a running target breaks in (crash/BSOD, breakpoint, or manual CTRL+BREAK).
+                Use after resuming with 'g' to wait for the target to stop on its own.
+                Returns all output kd produced when the break occurred (crash info, break-in banner, etc.).
+                """,
+                inputSchema=WaitForBreak.model_json_schema(),
+            ),
         ]
 
     @server.call_tool()
@@ -447,6 +462,10 @@ def _create_server(
 
             if name == "send_ctrl_break":
                 return filter_tool_content(name, _handle_send_ctrl_break(SendCtrlBreak(**arguments).session_id), call_id)
+
+            if name == "wait_for_break":
+                args = WaitForBreak(**arguments)
+                return filter_tool_content(name, _handle_wait_for_break(args), call_id)
 
             raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Unknown tool: {name}"))
 
@@ -584,6 +603,23 @@ def _create_server(
             ))
         session.send_ctrl_break()
         return [TextContent(type="text", text=f"Sent CTRL+BREAK to session {session_id} ({record['label']}).")]
+
+    def _handle_wait_for_break(args: WaitForBreak) -> list[TextContent]:
+        record = _sessions.get(args.session_id)
+        if record is None:
+            raise McpError(ErrorData(
+                code=INVALID_PARAMS,
+                message=f"Unknown session_id {args.session_id!r}. Open a session first."
+            ))
+        session = record["session"]
+        if not getattr(session, "is_live_session", False):
+            raise McpError(ErrorData(
+                code=INVALID_PARAMS,
+                message=f"session_id {args.session_id!r} is a dump session; wait_for_break requires a live target."
+            ))
+        output = session.wait_for_break(timeout=args.timeout_seconds)
+        text = "Target broke in.\n\nOutput:\n```\n" + "\n".join(output) + "\n```"
+        return [TextContent(type="text", text=text)]
 
     def _session_header(session_id: str, kind: str, what: str) -> str:
         run_tool = f"run_{kind}_command"


### PR DESCRIPTION
Fixes PRs
- https://github.com/svnscha/mcp-windbg/issues/71
- https://github.com/svnscha/mcp-windbg/issues/72 
- https://github.com/svnscha/mcp-windbg/issues/73

## Changelog

### Fix
- Named-pipe and COM/serial KD connections timing out on connect — banner detection only matched KDNET's "Connected to target", missing pipe/COM's "Kernel Debugger connection established"
- `g` (and all go-class commands) immediately re-halting the VM — `.echo MARKER` queued behind the running target, timed out, and CTRL+BREAK froze it again
- Commands sent after `g` silently re-halting the VM via the same timeout/CTRL+BREAK path — session had no concept of "target is running"

### Added
- `_target_running` state flag — set after go-commands, cleared on break-in; auto-breaks and resyncs before regular commands if target is still running
- `wait_for_break` MCP tool — blocks until crash/BSOD, breakpoint, or manual break; returns all kd output collected at halt (default 300s timeout)

### Removed
- Nothing