### PR TITLE
fix(deps): pin mcp dependency to <2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2.0.0",
     "pydantic>=2.13.4",
     "starlette>=1.3.1",
     "uvicorn>=0.51.0",


### PR DESCRIPTION
## Problem

  The recent release of mcp SDK v2.0.0 introduced breaking changes (removed @server.list_tools() on
  Server, renamed McpError). Fresh installs currently resolve mcp 2.0.0 and fail at startup:
  AttributeError: 'Server' object has no attribute 'list_tools'

  Refer to https://py.sdk.modelcontextprotocol.io/migration/

  ## Solution

  Pin the mcp dependency to mcp>=1.28.1,<2.0.0 in pyproject.toml to ensure stable installations
  under the supported mcp 1.x architecture.

  ## Verification

  • Verified python -m mcp_windbg --help loads and exits successfully with mcp 1.29.0.