### PR TITLE
Consolidate dependency updates (2 PRs)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,5 +4,5 @@
 #   python -m mkdocs build      # render static site into ./site
 # Mermaid diagrams use a small self-contained loader (docs/assets/mermaid.js).
 mkdocs>=1.6.1
-mkdocs-material>=9.7.6
-pymdown-extensions>=11.0
+mkdocs-material>=9.7.7
+pymdown-extensions>=11.0.1


### PR DESCRIPTION
Consolidates the following Dependabot PRs into a single update:

- #68 - ci(deps): bump actions/setup-python from 6 to 7 in the actions group
- #69 - deps(python): bump the python group with 2 updates (mkdocs-material 9.7.6 -> 9.7.7, pymdown-extensions 11.0 -> 11.0.1)

Supersedes #68
Supersedes #69

No lock file regeneration needed: neither bump touches `pyproject.toml`, and `uv lock --check` passes unchanged. `requirements-docs.txt` is a plain pip requirements file.

Verified locally:

- `uv run pytest src/mcp_windbg/tests/ -m "not live"` - 29 passed
- `python -m mkdocs build --strict` at the bumped docs versions - clean