### PR TITLE
Release 1.0.1: cap the mcp requirement below 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-08-21
+
+A single-line dependency fix, but an important one: every fresh install of 1.0.0 was broken.
+
+### Fixed
+
+- **Installs no longer pull an incompatible `mcp`** - the runtime requirement is now
+  `mcp>=1.28.1,<2.0.0`. `mcp` 2.0.0 renames `McpError` to `MCPError` and drops the low-level
+  `Server.list_tools()` decorator this server registers its tools with, so an unpinned install
+  resolved to 2.x and died at import with
+  `ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'` (#76). Thanks to
+  @aphroteus for the fix, and to @arjunarjun07 for pinning down the cause.
+
+  If you hit this on 1.0.0, upgrading is the fix: `pip install --upgrade mcp-windbg`. The manual
+  workaround (`pip install "mcp<2"`) is no longer needed.
+
+  Moving to the 2.x server API is tracked in #78.
+
 ## [1.0.0] - 2026-07-16
 
 First stable release, and the one where kernel debugging actually works.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-windbg"
-version = "1.0.0"
+version = "1.0.1"
 description = "A Model Context Protocol server providing tools to analyze Windows crash dumps using WinDbg/CDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/svnscha/mcp-windbg",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": {
         "type": "stdio"
       },
@@ -39,7 +39,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-windbg",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -677,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "mcp-windbg"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -705,7 +705,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.6" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.1" },
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0.2" },


### PR DESCRIPTION
Ships the `mcp<2.0.0` cap from #75 as an actual release.

## Why a release and not just `[Unreleased]`

pip reads dependency metadata from the **published wheel**, so merging the cap to `main` does nothing for anyone hitting #76 - 1.0.0 keeps resolving to `mcp` 2.x and keeps failing at import. The fix only reaches users when it is on PyPI.

## Changes

- `pyproject.toml`, `server.json` (top-level and both `packages[*]`), `CHANGELOG.md` bumped to 1.0.1
- `uv.lock` re-resolved
- CHANGELOG entry crediting @aphroteus and @arjunarjun07

No source changes beyond the dependency cap already merged in #75.

## Verified locally

- `scripts/check-version-consistency.ps1` - all four locations agree on 1.0.1
- `scripts/validate-server-schema.py` - server.json valid against the MCP registry schema
- `uv run pytest -m "not live"` - 29 passed
- `scripts/Format-Docs.ps1` - clean
- Built wheel metadata reads `Requires-Dist: mcp<2.0.0,>=1.28.1`, which is the part that actually fixes the user-visible bug

Closes #76.

Porting to the 2.x server API is tracked in #78.