### PR TITLE
Fix kernel go/break-in handling, add wait_for_break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`wait_for_break`** - block until a target you resumed stops again (bugcheck, breakpoint, or a
+  CTRL+BREAK from elsewhere) and return everything the debugger printed when it did. If the wait
+  expires the target is left running, so waiting never halts a machine behind your back.
+
+### Fixed
+
+- **`g` no longer freezes the target it was supposed to release** - go-class commands (`g`, `gh`,
+  `gn`, `gN`, `gc`, `gu`) hand the CPU back to the target, after which the debugger stops reading
+  its stdin. The marker protocol queued an `.echo` the debugger could not answer, so the command
+  hit its timeout and the cancel-on-timeout CTRL+BREAK halted the target again - the exact
+  opposite of what was asked. They are now written bare and return immediately. The step family
+  (`p`, `t`, `pa`, `ta`, ...) is unaffected: it returns to the prompt on its own and keeps the
+  marker round-trip (#74).
+- **An ordinary command after `g` breaks in by itself** - no need to interleave `send_ctrl_break`
+  manually, and whatever the target printed on the way to stopping leads that command's output
+  instead of being discarded.
+- **Break-in asks before it signals** - a CTRL+BREAK aimed at a target that has in fact already
+  stopped queues a break request a kernel target honours later, re-halting a machine we thought
+  we had released. The session probes for a prompt first and only signals if that goes
+  unanswered, which also makes `send_ctrl_break` safe to issue speculatively.
+- **`wait_for_break` trusts the debugger, not a flag** - it is right about a target running for
+  reasons this server never caused, and a second `g` while the target really is still running is
+  refused rather than queued behind the first.
+- **`bp nt!X; g` reports whether the breakpoint was set** - the part before the `g` runs with its
+  output returned, so a typo'd symbol surfaces as `Couldn't resolve error` rather than as a wait
+  for a break that can never arrive. A `;` inside a quoted command string is left alone.
+- **Output is no longer lost at a deadline** - a marker that lands in the moment between a timeout
+  expiring and being handled now counts as arrived, and the break-in output a timed-out command
+  was carrying rides along on the error instead of vanishing with it.
+- **One operation at a time per session** - `wait_for_break` parks for minutes on a worker thread
+  so the rest of the server keeps answering; a second call against the same session is refused
+  at once, with a message pointing at `send_ctrl_break`, rather than interleaving markers and
+  returning each other's output. The refusal never waits, so it cannot stall the server it exists
+  to keep responsive.
+- **Closing a session ends a wait parked on it** - instead of leaving a thread sitting out its
+  full timeout on a debugger that no longer exists and then reporting the target as still running.
+- **Kernel sessions over a named pipe or serial cable connect** - `kd` announces a COM/pipe link
+  with `Kernel Debugger connection established`, not the KDNET `Connected to target ...`. Only the
+  latter was matched, so `open_kd_session` timed out on a target that was in fact attached
+  (#47, #74).
+
 ## [1.0.1] - 2026-08-21
 
 A single-line dependency fix, but an important one: every fresh install of 1.0.0 was broken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **An ordinary command after `g` breaks in by itself** - no need to interleave `send_ctrl_break`
   manually, and whatever the target printed on the way to stopping leads that command's output
   instead of being discarded.
+- **A break-in issued the instant `g` returns is no longer swallowed** - resuming wrote the `g`
+  and returned without waiting for the debugger to read it, so for a moment the debugger was
+  still sitting at its prompt with the resume unread. A CTRL+BREAK arriving in that window was
+  answered by the prompt instead of reaching the target, and the break was simply lost: the
+  caller then waited out a full `wait_for_break` timeout on a machine nothing was going to stop.
+  Measured against a live KDNET target, a break sent with no gap after `g` was lost every single
+  time. The resume is now confirmed consumed before it is reported. A go-class command that stops
+  again at once - a `gu` returning in microseconds, a breakpoint hit immediately - reports what it
+  printed instead of claiming the target is running.
 - **Break-in asks before it signals** - a CTRL+BREAK aimed at a target that has in fact already
   stopped queues a break request a kernel target honours later, re-halting a machine we thought
   we had released. The session probes for a prompt first and only signals if that goes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not a magical auto-fix. It is a Python wrapper around `cdb.exe` / `kd.exe`
 
 ## Tools
 
-Every `open_*` tool returns an opaque **`session_id`** (e.g. `cdb-1a2b3c4d`); pass it to the matching `run_*`, `close_*`, and `send_ctrl_break` calls. User-mode targets (dumps and `-remote`) run under `cdb.exe`; kernel targets run under `kd.exe`.
+Every `open_*` tool returns an opaque **`session_id`** (e.g. `cdb-1a2b3c4d`); pass it to the matching `run_*`, `close_*`, `send_ctrl_break`, and `wait_for_break` calls. User-mode targets (dumps and `-remote`) run under `cdb.exe`; kernel targets run under `kd.exe`.
 
 | Tool | Purpose |
 |------|---------|
@@ -55,6 +55,7 @@ Every `open_*` tool returns an opaque **`session_id`** (e.g. `cdb-1a2b3c4d`); pa
 | `close_cdb_session` | Close a user-mode session |
 | `close_kd_session` | Close a kernel session (resumes the target machine) |
 | `send_ctrl_break` | Break into a running live session |
+| `wait_for_break` | Wait for a target you resumed with `g` to stop again |
 
 Parameters, timeouts, and the built-in triage prompts are in the [tools reference](https://svnscha.github.io/mcp-windbg/reference/tools/).
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -14,6 +14,7 @@ one from your request, but this is the precise contract for each.
 | [`close_cdb_session`](#close_cdb_session) | Close a user-mode session. |
 | [`close_kd_session`](#close_kd_session) | Close a kernel session. |
 | [`send_ctrl_break`](#send_ctrl_break) | Break into a running target. |
+| [`wait_for_break`](#wait_for_break) | Wait for a resumed target to stop. |
 
 ## Sessions and session ids
 
@@ -24,8 +25,8 @@ first line of its output, for example:
 session_id: cdb-1a2b3c4d
 ```
 
-Pass that id to every follow-up call for the session - `run_*`, `close_*`, and
-`send_ctrl_break`. Sessions are persistent (the `cdb.exe`/`kd.exe` process stays alive between
+Pass that id to every follow-up call for the session - `run_*`, `close_*`, `send_ctrl_break`,
+and `wait_for_break`. Sessions are persistent (the `cdb.exe`/`kd.exe` process stays alive between
 calls), and several can be open at once, so you can compare dumps side by side. Close sessions
 when you finish to free resources.
 
@@ -197,6 +198,59 @@ before inspecting a running remote session, or to halt a kernel target.
 A dump session has no running target, so this returns an error for `cdb` dump ids. Used by
 [Debug a remote target](../scenarios/remote-debugging.md) and
 [Debug a kernel target](../scenarios/kernel-debugging.md).
+
+---
+
+## wait_for_break
+
+Block until a target you resumed stops again - on a bugcheck, a breakpoint, or a CTRL+BREAK from
+elsewhere - and return everything the debugger printed when it did.
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `session_id` | yes | A live session id (cdb remote or kd) whose target is running. |
+| `timeout_seconds` | no | How long to wait. Defaults to 300. |
+
+It asks the debugger rather than trusting a flag, so it is right about a target that is running
+for reasons this server never caused - one resumed from the machine's own console, say. If the
+target is already stopped it returns immediately. If the wait expires the target is **left
+running**: wait again, or halt it with [`send_ctrl_break`](#send_ctrl_break).
+
+---
+
+## Letting the target run
+
+`g` and its relatives (`gh`, `gn`, `gN`, `gc`, `gu`) are different from every other command: they
+hand the CPU back to the target, and the debugger prints nothing more until it stops. Sent through
+[`run_cdb_command`](#run_cdb_command) or [`run_kd_command`](#run_kd_command) on a live session they
+return straight away, leaving the target running - they do not wait for output, and they do not
+count against the command timeout.
+
+From there you have three options:
+
+- [`wait_for_break`](#wait_for_break) - block until the target stops, and collect the bugcheck or
+  breakpoint report.
+- [`send_ctrl_break`](#send_ctrl_break) - halt it now.
+- Just send another command. The server breaks in for you first and puts whatever the target
+  printed on the way to stopping - the bugcheck banner, the breakpoint report - at the head of
+  that command's output, so the reason it stopped is never lost.
+
+Qualified and compound forms count too. `~0 g` and `~*g` resume the target, and in
+`bp nt!NtCreateFile; g` the breakpoint runs first with its result returned to you - so a typo'd
+symbol shows up as `Couldn't resolve error` instead of a wait for a break that can never come.
+A `;` inside a quoted command string (`bp X ".echo hit; g"`) belongs to the breakpoint, not to
+you, and is left alone.
+
+Stepping commands (`p`, `t`, `pa`, `ta`, ...) are *not* in this family: they run a single
+instruction or line and come back to the prompt, so they behave like any other command.
+
+A second `g` while the target really is still running is refused rather than queued - it would
+have resumed the target again the instant it stopped.
+
+While [`wait_for_break`](#wait_for_break) is parked on a session, other calls on that **same**
+session are refused immediately with a message pointing at
+[`send_ctrl_break`](#send_ctrl_break); other sessions keep working normally, and closing the
+session ends the wait.
 
 ---
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -226,6 +226,12 @@ hand the CPU back to the target, and the debugger prints nothing more until it s
 return straight away, leaving the target running - they do not wait for output, and they do not
 count against the command timeout.
 
+The server confirms the debugger actually took the resume before reporting it. Two things follow.
+If the target stops again immediately - a `gu` that returns in microseconds, or a breakpoint hit
+at once - you get that output instead of the "target resumed" message, because it never really
+left. And a [`send_ctrl_break`](#send_ctrl_break) issued in the same breath as the `g` still
+reaches the target, rather than being answered by a debugger that had not read the `g` yet.
+
 From there you have three options:
 
 - [`wait_for_break`](#wait_for_break) - block until the target stops, and collect the bugcheck or

--- a/src/mcp_windbg/debug_session.py
+++ b/src/mcp_windbg/debug_session.py
@@ -52,6 +52,16 @@ DEFAULT_WAIT_FOR_BREAK_TIMEOUT = 300
 # go-class command, and only when the target really is still going.
 BREAK_IN_PROBE_TIMEOUT = 2
 
+# How long a go-class command waits to see whether the debugger consumed it.
+# Until it has, the debugger is still sitting at its prompt with our ``g`` in
+# its input queue, and a CTRL+BREAK meant for the running target is answered by
+# that prompt instead - the break is swallowed and whoever sent it then waits
+# out a full timeout on a target nothing is going to stop. Reporting the resume
+# only once it has demonstrably taken effect closes that window. Measured
+# against a live KDNET target the debugger consumes it within ~50ms; the rest is
+# headroom for a loaded link.
+RESUME_CONFIRM_TIMEOUT = 0.5
+
 
 class DebuggerError(Exception):
     """Raised for any debugger session failure (launch, timeout, I/O)."""
@@ -503,12 +513,35 @@ class DebuggerSession:
         except (IOError, ValueError, AttributeError) as e:
             raise DebuggerError(f"Failed to send command: {e}")
         self._target_running = True
+
+        if not self._resume_took_effect():
+            # The debugger answered, so the target is already back at a prompt:
+            # a `gu` that returned in microseconds, or a breakpoint hit at once.
+            # Its output is the useful answer, not a claim that it is running.
+            self._target_running = False
+            return pending + self._take_output()
+
         return pending + [
             f"Target resumed with '{command}'; it is running and produces no "
             "output until it stops.",
             "Wait for it with wait_for_break, or halt it with send_ctrl_break. Any "
             "other command breaks in automatically first.",
         ]
+
+    def _resume_took_effect(self) -> bool:
+        """True once the debugger has consumed the resume and the target is away.
+
+        Probes with a marker the debugger can only answer from a prompt. Silence
+        means it has stopped reading stdin, which is exactly what running the
+        target looks like from here - and, crucially, means the resume is no
+        longer sitting unread in the input queue where it would swallow the next
+        CTRL+BREAK. An answer means the target never left, or came straight back.
+        """
+        try:
+            self._wait_for_prompt(RESUME_CONFIRM_TIMEOUT)
+        except DebuggerError:
+            return not self._abandon_marker()
+        return False
 
     def _break_in_and_resync(self) -> List[str]:
         """Get a running target back to a prompt, and return what it printed.

--- a/src/mcp_windbg/debug_session.py
+++ b/src/mcp_windbg/debug_session.py
@@ -18,6 +18,12 @@ Two robustness properties this base guarantees:
   executing it. We send CTRL+BREAK to break back in, drain to the pending
   marker, and only then report the timeout - leaving the session resynchronized
   instead of wedged.
+- **Go-class commands do not use the marker at all.** ``g`` and its relatives
+  hand the CPU back to the target, and the debugger stops reading stdin until
+  the target stops again. Marking them would queue an ``.echo`` the debugger
+  cannot answer, so the command would "time out" and the resulting CTRL+BREAK
+  would halt the target we just released. They are written bare instead, and
+  ``wait_for_break`` picks up whatever the target prints when it does stop.
 """
 
 from __future__ import annotations
@@ -36,9 +42,33 @@ PROMPT_REGEX = re.compile(r"^\d+:.*>\s*$")
 # appended so each command waits for its own, distinct marker.
 MARKER_BASE = "COMMAND_COMPLETED_MARKER"
 
+# How long ``wait_for_break`` blocks by default. Waiting on a resumed target is
+# open-ended by nature - you are waiting for a bugcheck or a breakpoint - so this
+# is deliberately unrelated to the per-command timeout.
+DEFAULT_WAIT_FOR_BREAK_TIMEOUT = 300
+
+# How long _break_in_and_resync waits for a target it believes is running to
+# answer on its own before resorting to CTRL+BREAK. Only ever paid after a
+# go-class command, and only when the target really is still going.
+BREAK_IN_PROBE_TIMEOUT = 2
+
 
 class DebuggerError(Exception):
     """Raised for any debugger session failure (launch, timeout, I/O)."""
+
+
+class _ReleaseOnExit:
+    """Context manager that releases an already-acquired lock on exit."""
+
+    def __init__(self, lock):
+        self._lock = lock
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        self._lock.release()
+        return False
 
 
 def build_debugger_args(
@@ -119,9 +149,21 @@ class DebuggerSession:
 
         self.output_lines: List[str] = []
         self.lock = threading.Lock()
+        #: Serializes whole operations on the debugger's stdin. ``self.lock``
+        #: only guards individual field writes; it cannot make "install a
+        #: marker, wait for it, take the output" atomic, and since
+        #: ``wait_for_break`` parks for minutes on a worker thread there is
+        #: real overlap to guard against. ``send_ctrl_break`` deliberately does
+        #: not take it - it is the escape hatch from a long wait.
+        self._io_lock = threading.RLock()
         self.ready_event = threading.Event()
         self._marker_seq = 0
         self._expected_marker: Optional[str] = None
+        #: True between a go-class command and the next break-in. While set, the
+        #: debugger is not reading its input, so the marker protocol is unusable.
+        self._target_running = False
+        #: Set by shutdown so a parked wait stops rather than outliving the session.
+        self._closing = False
 
         try:
             creationflags = 0
@@ -172,17 +214,21 @@ class DebuggerSession:
                     print(f"DBG > {line}")
 
                 with self.lock:
+                    if MARKER_BASE in line:
+                        # A marker line is ours, never the target's. Either it is
+                        # the one being waited on, or it is an earlier marker we
+                        # abandoned on a timeout - which must not be published as
+                        # if the debugger had printed it.
+                        self._on_output_line(line)
+                        if self._expected_marker and self._expected_marker in line:
+                            self.output_lines = buffer
+                            buffer = []
+                            self._expected_marker = None
+                            self.ready_event.set()
+                        continue
                     buffer.append(line)
                     self._on_output_line(line)
-                    if self._expected_marker and self._expected_marker in line:
-                        # Drop the marker line itself before publishing.
-                        if buffer and self._expected_marker in buffer[-1]:
-                            buffer.pop()
-                        self.output_lines = buffer
-                        buffer = []
-                        self._expected_marker = None
-                        self.ready_event.set()
-        except (IOError, ValueError) as e:
+        except (IOError, ValueError, AttributeError) as e:
             if self.verbose:
                 print(f"Debugger output reader error: {e}")
 
@@ -191,6 +237,51 @@ class DebuggerSession:
     def _next_marker(self) -> str:
         self._marker_seq += 1
         return f"{MARKER_BASE}_{self._marker_seq}"
+
+    def _take_output(self) -> List[str]:
+        """Detach and return whatever the reader has published."""
+        with self.lock:
+            result = self.output_lines.copy()
+            self.output_lines = []
+        return result
+
+    def _abandon_marker(self) -> bool:
+        """Give up on the marker currently being waited for.
+
+        Returns True if the marker in fact landed in the moment between the
+        deadline expiring and this call - in which case nothing was discarded
+        and the caller should treat its operation as having succeeded. The check
+        runs under ``self.lock``, which the reader also holds while it publishes,
+        so there is no window where a bugcheck banner can be thrown away for
+        having arrived a microsecond late.
+
+        Otherwise the ``.echo`` stays queued in the debugger and will print
+        whenever it finally gets read; the reader drops stray markers, so it goes
+        nowhere. What matters is that no later wait inherits this one's
+        half-finished state.
+        """
+        with self.lock:
+            if self._expected_marker is None and self.ready_event.is_set():
+                return True
+            self._expected_marker = None
+            self.output_lines = []
+        self.ready_event.clear()
+        return False
+
+    def _exclusive(self):
+        """Acquire the session's I/O lock, or explain why the session is busy.
+
+        Never waits. The server calls most tools straight from its event loop,
+        so blocking here would stall every other session too - and would stall
+        the very ``send_ctrl_break`` the failure message points at.
+        """
+        if not self._io_lock.acquire(blocking=False):
+            raise DebuggerError(
+                "This session is busy with another operation - most likely a "
+                "wait_for_break parked on a running target. Use send_ctrl_break "
+                "to stop the target, which ends the wait."
+            )
+        return _ReleaseOnExit(self._io_lock)
 
     def _wait_for_prompt(self, timeout: Optional[int] = None) -> None:
         """Send a bare marker and wait for it, proving the prompt is ready."""
@@ -201,11 +292,74 @@ class DebuggerSession:
         try:
             self.process.stdin.write(f".echo {marker}\n")
             self.process.stdin.flush()
-        except (IOError, ValueError) as e:
+        except (IOError, ValueError, AttributeError) as e:
             raise DebuggerError(f"Failed to communicate with debugger: {e}")
 
         if not self.ready_event.wait(timeout or self.timeout):
             raise DebuggerError("Timed out waiting for debugger prompt")
+
+    #: Commands that hand the target back its CPU and do not return to a prompt
+    #: on their own. The debugger stops reading stdin until the target stops
+    #: again, so the marker protocol cannot be used for these: the ``.echo``
+    #: would sit unread in the input queue, ``send_command`` would hit its
+    #: timeout, and the CTRL+BREAK that timeout fires would halt the very target
+    #: the command just released.
+    #:
+    #: The step family (``p``, ``t``, ``pa``, ``ta``, ``pt``, ``tt`` ...) is
+    #: deliberately absent. Those execute one instruction or source line and come
+    #: straight back to the prompt, so the normal marker round-trip is both
+    #: correct and necessary - classifying them as go-class would swallow their
+    #: output and leave the session wrongly believing the target is running.
+    #:
+    #: Not modelled: a go buried in a brace body, as in
+    #: ``.if (@eax==0) { g }``. Those still take the marker path and hit the
+    #: original timeout-then-CTRL+BREAK behaviour. Scripted control flow is rare
+    #: from a tool caller, and parsing it properly means parsing the debugger's
+    #: whole expression syntax; write the ``g`` as its own command instead.
+    _GO_COMMANDS = frozenset({"g", "gh", "gn", "gN", "gc", "gu"})
+
+    #: Leading thread/process qualifier, as in ``~0 g``, ``~*g``, ``|1s``.
+    _THREAD_QUALIFIER = re.compile(r"^[~|][0-9*.#]*\s*")
+
+    @staticmethod
+    def _split_segments(command: str) -> List[str]:
+        """Split a command line on ``;``, respecting double-quoted strings.
+
+        ``bp nt!NtCreateFile ".echo hit; g"`` is one command that sets a
+        breakpoint, not two of which the second resumes the target - the ``; g``
+        lives inside the breakpoint's own command string and runs later, if ever.
+        """
+        segments, current, in_quotes = [], [], False
+        for char in command:
+            if char == '"':
+                in_quotes = not in_quotes
+                current.append(char)
+            elif char == ";" and not in_quotes:
+                segments.append("".join(current))
+                current = []
+            else:
+                current.append(char)
+        segments.append("".join(current))
+        return segments
+
+    @classmethod
+    def _go_segment_index(cls, command: str) -> Optional[int]:
+        """Index of the first segment that hands the CPU back, or None.
+
+        Recognizes the qualified forms a caller actually writes, not just a bare
+        ``g``: ``g 0x7ffb1234``, ``~0 g``, ``~*g``.
+        """
+        for index, segment in enumerate(cls._split_segments(command)):
+            segment = cls._THREAD_QUALIFIER.sub("", segment.strip())
+            head = segment.split()[:1]
+            if head and head[0] in cls._GO_COMMANDS:
+                return index
+        return None
+
+    @classmethod
+    def _is_go_command(cls, command: str) -> bool:
+        """True if *command* hands the CPU back to the target."""
+        return cls._go_segment_index(command) is not None
 
     def send_command(self, command: str, timeout: Optional[int] = None) -> List[str]:
         """Send a command and return its output lines.
@@ -214,6 +368,12 @@ class DebuggerSession:
         CTRL+BREAK and the session is resynchronized before the timeout is
         reported, so the next command starts from a clean prompt.
 
+        Go-class commands on a live session are fire-and-forget: they are written
+        without a marker and return immediately, leaving the target running. Use
+        :meth:`wait_for_break` to block until it stops, or :meth:`send_ctrl_break`
+        to halt it. Issuing an ordinary command while the target runs breaks in
+        first, so callers never have to sequence that themselves.
+
         Raises:
             DebuggerError: if the process is gone, I/O fails, or the command
                 times out.
@@ -221,6 +381,24 @@ class DebuggerSession:
         if not self.process:
             raise DebuggerError("Debugger process is not running")
 
+        cmd_timeout = timeout or self.timeout
+
+        with self._exclusive():
+            if self.is_live_session:
+                go_at = self._go_segment_index(command)
+                if go_at is not None:
+                    return self._run_then_resume(command, go_at, cmd_timeout)
+
+            # Anything the target printed on the way to stopping - a bugcheck
+            # banner, a breakpoint report - is why it stopped, so it leads the
+            # output rather than being dropped on the floor.
+            preamble = self._break_in_and_resync() if self._target_running else []
+            return preamble + self._send_marked(command, cmd_timeout, preamble)
+
+    def _send_marked(
+        self, command: str, cmd_timeout: int, preamble: Optional[List[str]] = None
+    ) -> List[str]:
+        """Write *command* with a completion marker and return its output."""
         marker = self._next_marker()
         self.ready_event.clear()
         with self.lock:
@@ -230,21 +408,51 @@ class DebuggerSession:
         try:
             self.process.stdin.write(f"{command}\n.echo {marker}\n")
             self.process.stdin.flush()
-        except (IOError, ValueError) as e:
+        except (IOError, ValueError, AttributeError) as e:
             raise DebuggerError(f"Failed to send command: {e}")
 
-        cmd_timeout = timeout or self.timeout
-        if not self.ready_event.wait(cmd_timeout):
+        landed = self.ready_event.wait(cmd_timeout)
+        if self._closing:
+            raise DebuggerError("Session was closed while the command was running")
+        if not landed and not self._marker_landed():
             resynced = self._abort_running_command()
             detail = "" if resynced else " (session may need a manual break-in)"
+            # The break-in output is the only record of why the target stopped
+            # and would otherwise die with this exception, so it rides along.
+            lost = (
+                "\nThe target had stopped with:\n" + "\n".join(preamble)
+                if preamble
+                else ""
+            )
             raise DebuggerError(
-                f"Command timed out after {cmd_timeout} seconds: {command}{detail}"
+                f"Command timed out after {cmd_timeout} seconds: {command}{detail}{lost}"
             )
 
+        return self._take_output()
+
+    def _marker_landed(self) -> bool:
+        """True if the pending marker arrived just as the deadline expired."""
         with self.lock:
-            result = self.output_lines.copy()
-            self.output_lines = []
-        return result
+            return self._expected_marker is None and self.ready_event.is_set()
+
+    def _run_then_resume(self, command: str, go_at: int, cmd_timeout: int) -> List[str]:
+        """Run everything before the go segment, then resume with the rest.
+
+        ``bp nt!NtCreateFile; g`` is one line to the caller but two things to the
+        session. Sending it whole would throw away ``Breakpoint 0 set`` - or
+        ``Couldn't resolve error at 'nt!NtCreateFle'``, which is the difference
+        between waiting 300 seconds for a break and knowing it can never come.
+        """
+        segments = self._split_segments(command)
+        prefix = ";".join(segments[:go_at]).strip()
+        rest = ";".join(segments[go_at:]).strip()
+
+        output: List[str] = []
+        if prefix:
+            output.extend(self._break_in_and_resync() if self._target_running else [])
+            output.extend(self._send_marked(prefix, cmd_timeout, output))
+        output.extend(self._resume_target(rest))
+        return output
 
     def _abort_running_command(self) -> bool:
         """Break into a live target still running a timed-out command.
@@ -266,6 +474,148 @@ class DebuggerSession:
             self._expected_marker = None
         return resynced
 
+    def _resume_target(self, command: str) -> List[str]:
+        """Write a go-class command and return without waiting for a prompt.
+
+        Refuses to write a second one while the target is already running: the
+        debugger is not reading stdin, so it would sit queued and resume the
+        target again the moment it stopped - after which the session's idea of
+        what the target is doing would be wrong in the one direction that costs
+        a full command timeout to discover.
+        """
+        pending: List[str] = []
+        if self._target_running:
+            if self._still_running():
+                return [
+                    f"Target is already running; '{command}' was not sent. "
+                    f"Wait for it with wait_for_break, or halt it with send_ctrl_break."
+                ]
+            # It had stopped after all - an earlier send_ctrl_break landing, or a
+            # breakpoint. What it printed on the way is why, and leads the reply
+            # rather than being wiped by the next operation.
+            self._target_running = False
+            pending = self._take_output()
+        if self._abandon_marker():
+            pending.extend(self._take_output())
+        try:
+            self.process.stdin.write(f"{command}\n")
+            self.process.stdin.flush()
+        except (IOError, ValueError, AttributeError) as e:
+            raise DebuggerError(f"Failed to send command: {e}")
+        self._target_running = True
+        return pending + [
+            f"Target resumed with '{command}'; it is running and produces no "
+            "output until it stops.",
+            "Wait for it with wait_for_break, or halt it with send_ctrl_break. Any "
+            "other command breaks in automatically first.",
+        ]
+
+    def _break_in_and_resync(self) -> List[str]:
+        """Get a running target back to a prompt, and return what it printed.
+
+        Called automatically by :meth:`send_command` when an ordinary command is
+        issued while a go-class command still has the target running.
+
+        Asks before it signals, via :meth:`_still_running`. A CTRL+BREAK aimed at
+        a target that is in fact halted is not free - a kernel target queues the
+        break request and stops itself again later, after we thought we had
+        released it.
+
+        Raises:
+            DebuggerError: if the break-in signal fails or no prompt follows it.
+        """
+        if not self._still_running():
+            self._target_running = False
+            return self._take_output()
+
+        try:
+            self.process.send_signal(signal.CTRL_BREAK_EVENT)
+        except Exception as e:
+            raise DebuggerError(f"Failed to break into the running target: {e}")
+        try:
+            self._wait_for_prompt(min(10, max(3, self.timeout)))
+        except DebuggerError:
+            if not self._abandon_marker():
+                raise DebuggerError(
+                    "Target did not stop after CTRL+BREAK and is still running; "
+                    "it may be wedged below the debugger's reach."
+                ) from None
+        self._target_running = False
+        return self._take_output()
+
+    def _still_running(self) -> bool:
+        """Probe the debugger for a prompt; False means the target is stopped.
+
+        ``_target_running`` records that we resumed the target, not that it is
+        *still* going: a ``gu`` returns in microseconds, a ``g`` can hit a
+        breakpoint at once, and an earlier ``send_ctrl_break`` may already have
+        landed. Only the debugger knows, so ask it. On a False the output it
+        printed on the way to stopping is left published for the caller to take.
+        """
+        try:
+            self._wait_for_prompt(BREAK_IN_PROBE_TIMEOUT)
+        except DebuggerError:
+            return not self._abandon_marker()
+        return False
+
+    def wait_for_break(self, timeout: Optional[int] = None) -> List[str]:
+        """Block until a resumed target stops, and return what it printed.
+
+        Queues a marker into the debugger's stdin. While the target runs the
+        debugger is not reading input, so the marker sits there; when the target
+        stops - a bugcheck, a breakpoint, a manual break-in - the debugger drains
+        its input and echoes it. Everything printed in between (the crash banner,
+        the breakpoint report) arrives ahead of the marker and is returned.
+
+        The marker is queued unconditionally rather than short-circuiting on our
+        own "is it running" flag: the debugger answering at once *is* the proof
+        that the target is stopped, and it is right about targets this session
+        never resumed itself.
+
+        Args:
+            timeout: Seconds to wait. Not bounded by the session timeout: waiting
+                on a target is expected to be long.
+
+        Raises:
+            DebuggerError: if the process is gone, I/O fails, or the target is
+                still running when *timeout* expires.
+        """
+        if not self.process or self.process.poll() is not None:
+            raise DebuggerError("Debugger process is not running")
+
+        with self._exclusive():
+            return self._wait_for_break_locked(timeout)
+
+    def _wait_for_break_locked(self, timeout: Optional[int]) -> List[str]:
+        was_running = self._target_running
+        marker = self._next_marker()
+        self.ready_event.clear()
+        with self.lock:
+            self.output_lines = []
+            self._expected_marker = marker
+
+        try:
+            self.process.stdin.write(f".echo {marker}\n")
+            self.process.stdin.flush()
+        except (IOError, ValueError, AttributeError) as e:
+            raise DebuggerError(f"Failed to communicate with debugger: {e}")
+
+        wait = timeout or DEFAULT_WAIT_FOR_BREAK_TIMEOUT
+        landed = self.ready_event.wait(wait)
+        if self._closing:
+            raise DebuggerError("Session was closed while waiting for the target to stop")
+        if not landed and not self._abandon_marker():
+            raise DebuggerError(
+                f"Target did not stop within {wait} seconds and is still running. "
+                f"Wait again, or halt it with send_ctrl_break."
+            )
+
+        self._target_running = False
+        result = self._take_output()
+        if not was_running and not result:
+            return ["Target was already stopped; there was nothing to wait for."]
+        return result
+
     def send_ctrl_break(self) -> None:
         """Deliver CTRL+BREAK to break into a running target.
 
@@ -278,6 +628,11 @@ class DebuggerSession:
             self.process.send_signal(signal.CTRL_BREAK_EVENT)
         except Exception as e:
             raise DebuggerError(f"Failed to send CTRL+BREAK: {e}")
+        # _target_running is deliberately left alone. CTRL+BREAK only *requests*
+        # a break; over KDNET or a serial cable it can take seconds to land, and
+        # clearing the flag here would have the next command write into a
+        # debugger that is still not reading. Leaving it set costs one cheap
+        # probe in _break_in_and_resync, which resolves the truth either way.
 
     # -- Teardown ---------------------------------------------------------
 
@@ -297,7 +652,16 @@ class DebuggerSession:
         self.process.stdin.flush()
 
     def shutdown(self) -> None:
-        """Release the target, then terminate the debugger process."""
+        """Release the target, then terminate the debugger process.
+
+        Deliberately does not take ``_io_lock``: closing a session has to work
+        while a ``wait_for_break`` is parked on it, which is precisely when the
+        lock is held. Instead it flags the session closed and wakes the waiter,
+        which then reports the close rather than sitting out its full timeout on
+        a debugger that no longer exists.
+        """
+        self._closing = True
+        self.ready_event.set()
         try:
             if self.process and self.process.poll() is None:
                 try:

--- a/src/mcp_windbg/kd_session.py
+++ b/src/mcp_windbg/kd_session.py
@@ -33,10 +33,15 @@ from .debug_session import (
 # Raised for kernel session failures.
 KDError = DebuggerError
 
-# The banner ``kd`` prints once the kernel link is up (KDNET or COM). Matched as
-# a substring; the full line is e.g.
-#   "Connected to target 172.16.2.189 on port 50005 on local IP 172.16.2.183."
-KERNEL_CONNECTED_BANNER = "Connected to target"
+# The banners ``kd`` prints once the kernel link is up. They differ by transport,
+# and matching only the KDNET one made every pipe/serial session time out in
+# _startup even though the target was connected (#47). Matched as substrings:
+#   KDNET:       "Connected to target 172.16.2.189 on port 50005 on local IP ..."
+#   pipe/serial: "Kernel Debugger connection established."
+KERNEL_CONNECTED_BANNERS = (
+    "Connected to target",
+    "Kernel Debugger connection established",
+)
 
 # Default paths where kd.exe (kernel debugger) might be located.
 DEFAULT_KD_PATHS = [
@@ -114,7 +119,7 @@ class KDSession(DebuggerSession):
 
     def _on_output_line(self, line: str) -> None:
         """Notice the connect banner (called under the reader lock)."""
-        if KERNEL_CONNECTED_BANNER in line:
+        if any(banner in line for banner in KERNEL_CONNECTED_BANNERS):
             self._connected_event.set()
 
     def _startup(self) -> None:

--- a/src/mcp_windbg/prompts/kernel-triage.prompt.md
+++ b/src/mcp_windbg/prompts/kernel-triage.prompt.md
@@ -101,6 +101,10 @@ distinguish them.]
 - Never leave a session open at the end of an investigation. Release the target.
 - Do not send CTRL+BREAK right after opening. `open_kd_session` already broke in. Use
   `send_ctrl_break` only to re-halt a target you deliberately let run with `g`.
+- `g` returns immediately and leaves the machine running - it does not wait. To watch for the
+  bugcheck you expect, follow it with `wait_for_break`, which blocks until the target stops and
+  hands you what it printed. Any ordinary command breaks in by itself first, so you never have to
+  interleave `send_ctrl_break` manually.
 - Kernel commands can be slow on a busy machine or over a serial cable. Raise
   `timeout_seconds` on `run_kd_command` for heavy extensions (`!process 0 7`, `!poolused`)
   rather than declaring a hang.

--- a/src/mcp_windbg/prompts/remote-triage.prompt.md
+++ b/src/mcp_windbg/prompts/remote-triage.prompt.md
@@ -108,5 +108,8 @@ would distinguish them.]
   report a stale value as current.
 - Ask the user before anything that changes target state or execution (`g`, `p`, `t`, `bp`,
   `ed`). Inspection is safe; control is not.
+- `g` returns immediately and leaves the process running; it does not wait for anything. Use
+  `wait_for_break` to block until the target stops (a breakpoint, an exception), or just send the
+  next command - it breaks in by itself first.
 - If a command times out, the target may simply be busy. Raise `timeout_seconds` on
   `run_cdb_command` rather than declaring a hang.

--- a/src/mcp_windbg/server.py
+++ b/src/mcp_windbg/server.py
@@ -1,4 +1,5 @@
 import os
+import functools
 import traceback
 import glob
 import winreg
@@ -8,6 +9,7 @@ from typing import Dict, Optional
 from contextlib import asynccontextmanager
 
 from .cdb_session import CDBSession
+from .debug_session import DEFAULT_WAIT_FOR_BREAK_TIMEOUT
 from .kd_session import KDSession
 from .filter_script import FilterScript, load_filter_script
 from .prompts import load_prompt
@@ -27,6 +29,7 @@ from mcp.types import (
     INVALID_PARAMS,
     INTERNAL_ERROR,
 )
+import anyio.to_thread
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -42,6 +45,9 @@ CDB_REMOTE_OPEN_TIMEOUT = 60
 KD_OPEN_TIMEOUT = 60
 CDB_COMMAND_TIMEOUT = 60
 KD_COMMAND_TIMEOUT = 120
+# wait_for_break is not a command timeout: it is how long we are willing to sit
+# on a running target waiting for it to bugcheck or hit a breakpoint.
+WAIT_FOR_BREAK_TIMEOUT = DEFAULT_WAIT_FOR_BREAK_TIMEOUT
 
 
 def _effective_timeout(per_call: Optional[int], tool_default: int, server_timeout: int) -> int:
@@ -93,6 +99,31 @@ def _require_session(session_id: str, kind: str):
             ),
         ))
     return record["session"]
+
+
+def _require_live_session(session_id: str, what: str):
+    """Return the session for ``session_id``, requiring a live (non-dump) target.
+
+    Shared by the tools that only make sense against something that runs -
+    ``send_ctrl_break`` and ``wait_for_break`` - and accepts either kind, since a
+    cdb remote and a kd session both have a target to stop.
+    """
+    record = _sessions.get(session_id)
+    if record is None:
+        raise McpError(ErrorData(
+            code=INVALID_PARAMS,
+            message=f"Unknown session_id {session_id!r}. Open a session first.",
+        ))
+    session = record["session"]
+    if not getattr(session, "is_live_session", False):
+        raise McpError(ErrorData(
+            code=INVALID_PARAMS,
+            message=(
+                f"session_id {session_id!r} is a dump session; there is no "
+                f"running target to {what}."
+            ),
+        ))
+    return session
 
 
 def _close_session(session_id: str, kind: str) -> bool:
@@ -200,6 +231,12 @@ class CloseKdSession(BaseModel):
 class SendCtrlBreak(BaseModel):
     """Parameters for breaking into a running session."""
     session_id: str = Field(description="A live session_id (cdb remote or kd) to break into.")
+
+
+class WaitForBreak(BaseModel):
+    """Parameters for waiting until a resumed target stops."""
+    session_id: str = Field(description="A live session_id (cdb remote or kd) whose target is running.")
+    timeout_seconds: Optional[int] = Field(default=None, description=f"Maximum seconds to wait (default {WAIT_FOR_BREAK_TIMEOUT}). The target stops on a crash/bugcheck, a breakpoint, or a CTRL+BREAK from elsewhere.")
 
 
 def _combine_symbols(per_call: Optional[str], server_default: Optional[str]) -> Optional[str]:
@@ -399,6 +436,17 @@ def _create_server(
                 """,
                 inputSchema=SendCtrlBreak.model_json_schema(),
             ),
+            Tool(
+                name="wait_for_break",
+                description="""
+                Block until a resumed target stops, and return everything it printed when it did.
+                Use this after letting the target run with 'g' - to catch the bugcheck, the
+                breakpoint report, or the break-in banner. Returns immediately if the target is
+                already stopped. If it is still running when the wait expires, the target is left
+                running: wait again, or halt it with send_ctrl_break.
+                """,
+                inputSchema=WaitForBreak.model_json_schema(),
+            ),
         ]
 
     @server.call_tool()
@@ -447,6 +495,9 @@ def _create_server(
 
             if name == "send_ctrl_break":
                 return filter_tool_content(name, _handle_send_ctrl_break(SendCtrlBreak(**arguments).session_id), call_id)
+
+            if name == "wait_for_break":
+                return filter_tool_content(name, await _handle_wait_for_break(WaitForBreak(**arguments)), call_id)
 
             raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Unknown tool: {name}"))
 
@@ -570,20 +621,33 @@ def _create_server(
         return [TextContent(type="text", text=f"No active {kind} session found for session_id {session_id}")]
 
     def _handle_send_ctrl_break(session_id) -> list[TextContent]:
-        record = _sessions.get(session_id)
-        if record is None:
-            raise McpError(ErrorData(
-                code=INVALID_PARAMS,
-                message=f"Unknown session_id {session_id!r}. Open a session first."
-            ))
-        session = record["session"]
-        if not getattr(session, "is_live_session", False):
-            raise McpError(ErrorData(
-                code=INVALID_PARAMS,
-                message=f"session_id {session_id!r} is a dump session; there is no running target to break into."
-            ))
+        session = _require_live_session(session_id, "break into")
+        label = _sessions[session_id]["label"]
         session.send_ctrl_break()
-        return [TextContent(type="text", text=f"Sent CTRL+BREAK to session {session_id} ({record['label']}).")]
+        return [TextContent(type="text", text=f"Sent CTRL+BREAK to session {session_id} ({label}).")]
+
+    async def _handle_wait_for_break(args: WaitForBreak) -> list[TextContent]:
+        session = _require_live_session(args.session_id, "wait on")
+        # Deliberately not _effective_timeout: the --timeout floor is about how
+        # long a *command* may take, and has nothing to say about how long you
+        # are willing to sit on a target waiting for it to bugcheck.
+        wait = (
+            args.timeout_seconds
+            if args.timeout_seconds and args.timeout_seconds > 0
+            else WAIT_FOR_BREAK_TIMEOUT
+        )
+        # This blocks for minutes by design. Run it on a worker thread so the
+        # event loop keeps serving - otherwise the server could not answer the
+        # send_ctrl_break this tool's own timeout message tells you to use.
+        output = await anyio.to_thread.run_sync(
+            functools.partial(session.wait_for_break, timeout=wait)
+        )
+        if not output:
+            return [TextContent(type="text", text="Target stopped, printing nothing.")]
+        return [TextContent(
+            type="text",
+            text="Target stopped.\n\nOutput:\n```\n" + "\n".join(output) + "\n```",
+        )]
 
     def _session_header(session_id: str, kind: str, what: str) -> str:
         run_tool = f"run_{kind}_command"

--- a/src/mcp_windbg/tests/scenarios/kernel_resume_and_wait.yaml
+++ b/src/mcp_windbg/tests/scenarios/kernel_resume_and_wait.yaml
@@ -1,0 +1,89 @@
+name: Resume and wait against a real kernel target
+description: >
+  The kernel half of resume_and_wait.yaml, against the machine the bugs were
+  reported on (#71, #72, #73). 'g' releases the target instead of the timeout
+  handler re-freezing it, an ordinary command afterwards breaks in by itself,
+  and a CTRL+BREAK issued the instant 'g' returns is not swallowed by a
+  debugger that had not read the 'g' yet. Needs a live target: set
+  MCP_WINDBG_KERNEL_CONNECTION to its -k connection string (see CLAUDE.md).
+requires:
+  kernel: true
+server:
+  args: ["--kd-path", "{kd}", "--timeout", "120"]
+steps:
+  - call: open_kd_session
+    arguments:
+      connection_string: "{kernel}"
+    capture:
+      sid: 'session_id:\s*(kd-[0-9a-f]+)'
+    expect:
+      isError: false
+
+  # Before the fix this sat until the command timeout and then CTRL+BREAK'd the
+  # machine back to a halt - the exact opposite of what 'g' asked for (#72).
+  - call: run_kd_command
+    arguments:
+      session_id: "{sid}"
+      command: "g"
+    expect:
+      isError: false
+      contains:
+        - "resumed"
+
+  # An ordinary command while the machine runs breaks in on its own and returns
+  # real output, rather than timing out and freezing the VM as a side effect (#73).
+  - call: run_kd_command
+    arguments:
+      session_id: "{sid}"
+      command: "vertarget"
+    expect:
+      isError: false
+      contains:
+        - "Kernel Version"
+
+  - call: run_kd_command
+    arguments:
+      session_id: "{sid}"
+      command: "g"
+    expect:
+      isError: false
+      contains:
+        - "resumed"
+
+  # The race: this break lands with no gap at all after the 'g' above. Until the
+  # resume is confirmed consumed, the debugger is still at its prompt and answers
+  # the break itself - it never reaches the target, and the wait below then sits
+  # out its full timeout on a machine nothing is going to stop.
+  - call: send_ctrl_break
+    arguments:
+      session_id: "{sid}"
+    expect:
+      isError: false
+
+  - call: wait_for_break
+    arguments:
+      session_id: "{sid}"
+      timeout_seconds: 30
+    expect:
+      isError: false
+      contains:
+        - "Break instruction exception"
+
+  # The session is still usable at a clean prompt afterwards.
+  - call: run_kd_command
+    arguments:
+      session_id: "{sid}"
+      command: "vertarget"
+    expect:
+      isError: false
+      contains:
+        - "Kernel Version"
+
+  # resume: true leaves the machine running rather than frozen at the break.
+  - call: close_kd_session
+    arguments:
+      session_id: "{sid}"
+      resume: true
+    expect:
+      contains:
+        - "Successfully closed kd session"

--- a/src/mcp_windbg/tests/scenarios/resume_and_wait.yaml
+++ b/src/mcp_windbg/tests/scenarios/resume_and_wait.yaml
@@ -1,0 +1,78 @@
+name: Resume a target and wait for it
+description: >
+  'g' through run_cdb_command resumes the target instead of hanging, an ordinary
+  command afterwards breaks in by itself, and wait_for_break reports a target
+  that is still running rather than halting it.
+requires:
+  remote:
+    target: ["waitfor.exe", "SomeSignalThatNeverComes"]   # blocks forever once resumed
+steps:
+  - call: open_cdb_remote
+    arguments:
+      connection_string: "{remote}"
+    capture:
+      sid: 'session_id:\s*(cdb-[0-9a-f]+)'
+    expect:
+      isError: false
+
+  # Before the fix this sat until the command timeout and then CTRL+BREAK'd the
+  # target back to a halt - the opposite of what 'g' asked for.
+  - call: run_cdb_command
+    arguments:
+      session_id: "{sid}"
+      command: "g"
+    expect:
+      isError: false
+      contains:
+        - "resumed"
+
+  # An ordinary command breaks in on its own, so callers never sequence it.
+  - call: run_cdb_command
+    arguments:
+      session_id: "{sid}"
+      command: "r"
+    expect:
+      isError: false
+      contains:
+        - "Break instruction exception"
+
+  - call: run_cdb_command
+    arguments:
+      session_id: "{sid}"
+      command: "g"
+    expect:
+      isError: false
+
+  # This target never stops by itself, so the wait expires and says so - and
+  # leaves the target running rather than halting it behind the caller's back.
+  - call: wait_for_break
+    arguments:
+      session_id: "{sid}"
+      timeout_seconds: 2
+    expect:
+      isError: true
+      contains:
+        - "still running"
+
+  - call: send_ctrl_break
+    arguments:
+      session_id: "{sid}"
+    expect:
+      isError: false
+
+  # send_ctrl_break only requests a break; wait_for_break establishes that it
+  # actually landed, and returns the banner the debugger printed when it did.
+  - call: wait_for_break
+    arguments:
+      session_id: "{sid}"
+      timeout_seconds: 30
+    expect:
+      isError: false
+      contains:
+        - "Break instruction exception"
+
+  - call: close_cdb_session
+    arguments:
+      session_id: "{sid}"
+    expect:
+      isError: false

--- a/src/mcp_windbg/tests/scenarios/tools_contract.yaml
+++ b/src/mcp_windbg/tests/scenarios/tools_contract.yaml
@@ -1,5 +1,5 @@
 name: Tools contract
-description: The server advertises exactly the nine harmonized, session-id tools.
+description: The server advertises exactly the ten harmonized, session-id tools.
 steps:
   - list_tools: true
     expect:
@@ -13,6 +13,7 @@ steps:
         - close_cdb_session
         - close_kd_session
         - send_ctrl_break
+        - wait_for_break
       not_contains:
         - open_windbg_dump
         - run_windbg_cmd

--- a/src/mcp_windbg/tests/test_debug_session.py
+++ b/src/mcp_windbg/tests/test_debug_session.py
@@ -155,6 +155,7 @@ def _fast_break_in_probe(monkeypatch):
     is about a slow kernel cable; the fake answers instantly or not at all, so
     shorten it and keep the suite quick."""
     monkeypatch.setattr(debug_session, "BREAK_IN_PROBE_TIMEOUT", 0.2)
+    monkeypatch.setattr(debug_session, "RESUME_CONFIRM_TIMEOUT", 0.2)
 
 
 @pytest.fixture(autouse=True)
@@ -211,8 +212,10 @@ def test_go_command_returns_immediately_and_leaves_target_running(make_session):
     assert proc.running is True
     assert session._target_running is True
     assert any("resumed" in line.lower() for line in out)
-    # No marker was queued behind the go command.
-    assert proc._queued == []
+    # What is queued behind the go is the probe that confirms the debugger
+    # consumed it, and nothing else. It is deliberately not a completion marker
+    # the command waits on: this call returned with the target still running.
+    assert proc._queued and all(line.startswith(".echo ") for line in proc._queued)
 
 
 def test_go_command_with_an_argument_is_still_go(make_session):
@@ -231,6 +234,25 @@ def test_step_commands_are_not_treated_as_go(make_session, command):
     assert out == [f"OUT:{command}"]
     assert session._target_running is False
     assert proc.running is False
+
+
+def test_go_that_stops_at_once_reports_the_stop_not_a_resume(make_session):
+    """A ``gu`` that returns in microseconds, or a breakpoint hit immediately,
+    leaves the target back at a prompt. Reporting "target resumed" there is two
+    lies for the price of one: it discards the output the caller wanted, and it
+    leaves ``_target_running`` set so the next ordinary command breaks into a
+    target that already stopped.
+
+    Confirming the resume is what makes this distinguishable - the debugger
+    answering the probe *is* the evidence the target never left.
+    """
+    session, proc = make_session(live=True)
+    proc._resumes_on_go = False  # the target comes straight back to the prompt
+    out = session.send_command("gu")
+    assert session._target_running is False
+    assert proc.running is False
+    assert out == ["OUT:gu"]
+    assert not any("resumed" in line.lower() for line in out)
 
 
 def test_go_on_a_dump_session_uses_the_normal_marker_protocol(make_session):

--- a/src/mcp_windbg/tests/test_debug_session.py
+++ b/src/mcp_windbg/tests/test_debug_session.py
@@ -1,16 +1,19 @@
-"""Hermetic test for the DebuggerSession command timeout.
+"""Hermetic tests for DebuggerSession's timeout and go/break-in handling.
 
 The scenarios drive a real debugger and cover the marker protocol's happy path
 (a command returns its own output) far better than a fake can. What they cannot
-do is make a debugger stop answering: hanging a real cdb.exe on demand is not
-something a scenario can arrange. So the fake in-process "debugger" here exists
-for that one case - it can be told to swallow markers, leaving the command to
-time out and exercise the cancel-on-timeout resync.
+do is make a debugger stop answering, or make a target bugcheck on cue. So the
+fake in-process "debugger" here covers those: it can be told to swallow markers
+(exercising the cancel-on-timeout resync), and it models the one behaviour that
+makes go-class commands special - while the target runs, the debugger stops
+reading its stdin, so anything written to it is queued until the target stops.
 """
 
 from __future__ import annotations
 
 import queue
+import threading
+import time
 
 import pytest
 
@@ -18,6 +21,9 @@ from mcp_windbg import debug_session
 from mcp_windbg.debug_session import DebuggerError, DebuggerSession
 
 _STOP = object()
+
+# Commands the fake debugger recognizes as resuming the target.
+_GO = ("g", "gh", "gn", "gN", "gc", "gu")
 
 
 class _FakeStdin:
@@ -48,35 +54,84 @@ class _FakeStdout:
 
 
 class _FakeProc:
-    """Minimal subprocess.Popen stand-in driven by what is written to stdin."""
+    """Minimal subprocess.Popen stand-in driven by what is written to stdin.
 
-    def __init__(self, *, swallow_markers: bool = False):
+    Args:
+        swallow_markers: never echo ``.echo <marker>`` back, i.e. never finish a
+            command - used to force the timeout path.
+        resumes_on_go: model a live target. A go-class command sets the process
+            "running": from then on stdin is queued rather than processed, the
+            way a real debugger stops reading input once the target has the CPU.
+            Only :meth:`target_stops` (a bugcheck/breakpoint) or CTRL+BREAK
+            drains that queue.
+    """
+
+    def __init__(
+        self,
+        *,
+        swallow_markers: bool = False,
+        resumes_on_go: bool = False,
+        breaks_on_signal: bool = True,
+    ):
         self._out: "queue.Queue" = queue.Queue()
         self._swallow = swallow_markers
+        self._resumes_on_go = resumes_on_go
+        self._breaks_on_signal = breaks_on_signal
         self.stdin = _FakeStdin(self)
         self.stdout = _FakeStdout(self)
         self._alive = True
         self.pid = 4321
         self.signals: list = []
+        self.running = False
+        self._queued: list = []
+        #: When set, answer this many more markers and swallow the rest. Lets a
+        #: test hang one specific command without also hanging the break-in
+        #: probe that precedes it.
+        self.answer_budget: "int | None" = None
 
     def _feed(self, text: str):
         for line in text.splitlines():
-            if line.startswith(".echo "):
-                marker = line[len(".echo "):]
-                if not self._swallow:
-                    self._out.put(marker)
-            elif line in ("q", "\x02"):
-                # quit / detach: the real process exits, ending the reader loop
-                self._alive = False
-                self._out.put(_STOP)
+            if self.running:
+                self._queued.append(line)  # target has the CPU; stdin is not read
             else:
-                self._out.put(f"OUT:{line}")
+                self._handle(line)
+
+    def _handle(self, line: str):
+        if line.startswith(".echo "):
+            marker = line[len(".echo "):]
+            if self.answer_budget is not None:
+                if self.answer_budget <= 0:
+                    return
+                self.answer_budget -= 1
+            if not self._swallow:
+                self._out.put(marker)
+        elif line in ("q", "\x02"):
+            # quit / detach: the real process exits, ending the reader loop
+            self._alive = False
+            self._out.put(_STOP)
+        elif self._resumes_on_go and line.split()[:1] and line.split()[0] in _GO:
+            self.running = True
+        else:
+            self._out.put(f"OUT:{line}")
+
+    def target_stops(self, *lines: str):
+        """The target halts on its own (bugcheck, breakpoint), draining stdin."""
+        if not self.running:
+            return
+        self.running = False
+        for line in lines:
+            self._out.put(line)
+        queued, self._queued = self._queued, []
+        for line in queued:
+            self._handle(line)
 
     def poll(self):
         return None if self._alive else 0
 
     def send_signal(self, sig):
         self.signals.append(sig)
+        if self._breaks_on_signal:
+            self.target_stops("Break instruction exception - code 80000003 (first chance)")
 
     def terminate(self):
         self._alive = False
@@ -90,25 +145,48 @@ class _Session(DebuggerSession):
     is_live_session = False
 
 
+class _LiveSession(DebuggerSession):
+    is_live_session = True
+
+
+@pytest.fixture(autouse=True)
+def _fast_break_in_probe(monkeypatch):
+    """_break_in_and_resync probes for a prompt before signalling. The real 2s
+    is about a slow kernel cable; the fake answers instantly or not at all, so
+    shorten it and keep the suite quick."""
+    monkeypatch.setattr(debug_session, "BREAK_IN_PROBE_TIMEOUT", 0.2)
+
+
+@pytest.fixture(autouse=True)
+def _ctrl_break_event(monkeypatch):
+    """CTRL_BREAK_EVENT only exists on Windows, and the fake process never
+    delivers a real signal - so define it where it is missing and let the
+    break-in paths be exercised on any platform."""
+    monkeypatch.setattr(debug_session.signal, "CTRL_BREAK_EVENT", 21, raising=False)
+
+
 @pytest.fixture
 def make_session(monkeypatch):
     """Build a session over a fake process. Markers always work during startup;
     the returned proc can be switched to swallow markers afterwards."""
-    created = {}
+    created = []
 
-    def _factory(timeout=5):
-        proc = _FakeProc()
+    def _factory(timeout=5, live=False, breaks_on_signal=True):
+        proc = _FakeProc(resumes_on_go=live, breaks_on_signal=breaks_on_signal)
         monkeypatch.setattr(debug_session.subprocess, "Popen", lambda *a, **k: proc)
-        session = _Session(
+        cls = _LiveSession if live else _Session
+        session = cls(
             debugger_path="fake", launch_args=["fake"], timeout=timeout, verbose=False
         )
-        created["session"] = session
+        created.append(session)
         return session, proc
 
     yield _factory
-    session = created.get("session")
-    if session is not None:
-        session.shutdown()
+    for session in created:
+        try:
+            session.shutdown()
+        except Exception:
+            pass
 
 
 def test_timeout_raises_when_marker_never_arrives(make_session):
@@ -117,3 +195,385 @@ def test_timeout_raises_when_marker_never_arrives(make_session):
     with pytest.raises(DebuggerError) as exc:
         session.send_command("hangs")
     assert "timed out" in str(exc.value).lower()
+
+
+# -- go-class commands ----------------------------------------------------
+#
+# The bug these cover: 'g' hands the CPU to the target, after which the debugger
+# stops reading stdin. Marking the command would queue an .echo the debugger
+# cannot answer, so send_command would "time out" and its cancel-on-timeout
+# CTRL+BREAK would halt the very target 'g' had just released.
+
+
+def test_go_command_returns_immediately_and_leaves_target_running(make_session):
+    session, proc = make_session(live=True)
+    out = session.send_command("g")
+    assert proc.running is True
+    assert session._target_running is True
+    assert any("resumed" in line.lower() for line in out)
+    # No marker was queued behind the go command.
+    assert proc._queued == []
+
+
+def test_go_command_with_an_argument_is_still_go(make_session):
+    session, proc = make_session(live=True)
+    session.send_command("g 0x7ffb1234")
+    assert session._target_running is True
+
+
+@pytest.mark.parametrize("command", ["p", "t", "pa", "ta", "pt", "tt", "gu_not_a_command"])
+def test_step_commands_are_not_treated_as_go(make_session, command):
+    """Stepping returns to the prompt on its own, so it must keep the marker
+    round-trip - otherwise its output is swallowed and the session wrongly
+    believes the target is running."""
+    session, proc = make_session(live=True)
+    out = session.send_command(command)
+    assert out == [f"OUT:{command}"]
+    assert session._target_running is False
+    assert proc.running is False
+
+
+def test_go_on_a_dump_session_uses_the_normal_marker_protocol(make_session):
+    """A dump has no target to resume; 'g' there is just another command."""
+    session, _ = make_session(live=False)
+    assert session.send_command("g") == ["OUT:g"]
+    assert session._target_running is False
+
+
+def test_ordinary_command_breaks_in_first_when_the_target_is_running(make_session):
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    out = session.send_command("k")
+    assert debug_session.signal.CTRL_BREAK_EVENT in proc.signals
+    # Why the target stopped leads the output; it is not dropped on the floor.
+    assert out == ["Break instruction exception - code 80000003 (first chance)", "OUT:k"]
+    assert session._target_running is False
+
+
+def test_break_in_probes_before_signalling_an_already_stopped_target(make_session):
+    """A CTRL+BREAK aimed at a halted kernel target queues a break request that
+    stops the machine again later, so the probe has to come first."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    proc.target_stops("Breakpoint 0 hit")  # stopped on its own; we do not know yet
+    out = session.send_command("k")
+    assert proc.signals == []  # no stray CTRL+BREAK
+    assert out == ["Breakpoint 0 hit", "OUT:k"]
+    assert session._target_running is False
+
+
+def test_send_ctrl_break_does_not_assume_the_break_landed(make_session):
+    """CTRL+BREAK only requests a break. The flag stays set and the next
+    command's probe establishes the truth - one cheap round-trip, no lie."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    session.send_ctrl_break()
+    assert session._target_running is True
+    before = len(proc.signals)
+    out = session.send_command("k")
+    assert len(proc.signals) == before  # probe answered; no second signal
+    assert out == ["Break instruction exception - code 80000003 (first chance)", "OUT:k"]
+    assert session._target_running is False
+
+
+def test_a_second_go_is_refused_while_the_target_is_running(make_session):
+    """Writing it would queue a resume that fires the moment the target stops,
+    leaving the session's view of the target wrong."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    out = session.send_command("g")
+    assert any("already running" in line for line in out)
+    # Only the probe's marker was queued - never a second resume, which would
+    # have fired the instant the target stopped.
+    assert [line for line in proc._queued if not line.startswith(".echo ")] == []
+    assert session._target_running is True
+
+
+def test_break_in_failure_leaves_no_marker_pending(make_session):
+    """If CTRL+BREAK does not land, the abandoned marker must not surface later
+    as a phantom completion for whatever runs next."""
+    session, proc = make_session(timeout=3, live=True, breaks_on_signal=False)
+    session.send_command("g")
+    with pytest.raises(DebuggerError) as exc:
+        session.send_command("k")
+    assert "did not stop after CTRL+BREAK" in str(exc.value)
+    assert session._expected_marker is None
+    assert session._target_running is True
+
+    # The target finally stops; the queued markers echo but are dropped as ours,
+    # so the next command sees only real output.
+    proc.target_stops("Breakpoint 0 hit")
+    out = session.send_command("k")
+    assert not any(debug_session.MARKER_BASE in line for line in out)
+    assert out[-1] == "OUT:k"
+
+
+# -- wait_for_break -------------------------------------------------------
+
+
+def test_wait_for_break_returns_what_the_target_printed_when_it_stopped(make_session):
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    timer = threading.Timer(
+        0.05, lambda: proc.target_stops("*** Fatal System Error: 0x0000007e")
+    )
+    timer.start()
+    try:
+        out = session.wait_for_break(timeout=5)
+    finally:
+        timer.cancel()
+    assert any("Fatal System Error" in line for line in out)
+    assert session._target_running is False
+
+
+def test_wait_for_break_says_so_when_the_target_is_already_stopped(make_session):
+    session, _ = make_session(live=True)
+    out = session.wait_for_break(timeout=5)
+    assert out == ["Target was already stopped; there was nothing to wait for."]
+
+
+def test_wait_for_break_asks_the_debugger_not_its_own_flag(make_session):
+    """A target can be running for reasons this session never caused - resumed
+    from the target console, or already going when the session was opened. The
+    marker coming back is the proof it stopped; the flag is not."""
+    session, proc = make_session(live=True)
+    proc.running = True  # running, but _target_running was never set
+    assert session._target_running is False
+    timer = threading.Timer(0.05, lambda: proc.target_stops("*** Fatal System Error"))
+    timer.start()
+    try:
+        out = session.wait_for_break(timeout=5)
+    finally:
+        timer.cancel()
+    assert any("Fatal System Error" in line for line in out)
+
+
+def test_wait_for_break_times_out_and_leaves_the_target_running(make_session):
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    with pytest.raises(DebuggerError) as exc:
+        session.wait_for_break(timeout=1)
+    assert "still running" in str(exc.value)
+    # Still running, so the caller can wait again or break in.
+    assert session._target_running is True
+    assert proc.running is True
+
+
+def test_wait_for_break_after_a_timeout_still_reports_the_stop(make_session):
+    """The abandoned marker echoes harmlessly; the second wait gets the stop."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    with pytest.raises(DebuggerError):
+        session.wait_for_break(timeout=1)
+    timer = threading.Timer(0.05, lambda: proc.target_stops("Breakpoint 0 hit"))
+    timer.start()
+    try:
+        out = session.wait_for_break(timeout=5)
+    finally:
+        timer.cancel()
+    assert any("Breakpoint 0 hit" in line for line in out)
+    # The marker abandoned by the first wait echoed on the way past; it is ours,
+    # not the target's, and must not be reported as debugger output.
+    assert not any(debug_session.MARKER_BASE in line for line in out)
+
+
+# -- go classification ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "g",
+        "  g  ",
+        "g 0x7ffb1234",
+        "gh",
+        "gn",
+        "gN",
+        "gc",
+        "gu",
+        "~0 g",          # thread-qualified
+        "~*g",
+        "bp nt!NtCreateFile; g",   # the usual set-a-breakpoint-and-continue
+        "g; k",
+    ],
+)
+def test_is_go_command_recognizes_the_forms_callers_actually_write(command):
+    assert DebuggerSession._is_go_command(command) is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "",
+        "   ",
+        "k",
+        "p", "t", "pa", "ta", "pt", "tt",   # stepping returns to the prompt
+        "~",
+        "|1s",
+        ".echo gone",
+        "bp g",          # a breakpoint on a symbol named g
+        "!analyze -v",
+        "lm m nt",
+    ],
+)
+def test_is_go_command_rejects_everything_else(command):
+    assert DebuggerSession._is_go_command(command) is False
+
+
+# -- concurrency and lost-output regressions ------------------------------
+#
+# wait_for_break parks for minutes on a worker thread (the server runs it via
+# anyio.to_thread so the event loop keeps serving), which is the first time two
+# operations can genuinely overlap on one session.
+
+
+def test_a_command_during_a_parked_wait_is_refused_not_interleaved(make_session):
+    """Interleaving would let each operation install its marker over the
+    other's, and both would return the wrong output - silently."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+
+    errors: list = []
+    started = threading.Event()
+
+    def _wait():
+        started.set()
+        try:
+            session.wait_for_break(timeout=2)
+        except DebuggerError:
+            pass
+
+    waiter = threading.Thread(target=_wait, daemon=True)
+    waiter.start()
+    started.wait()
+    time.sleep(0.2)  # let the waiter get past acquiring the session
+    began = time.monotonic()
+    try:
+        session.send_command("k", timeout=60)
+    except DebuggerError as exc:
+        errors.append(str(exc))
+    elapsed = time.monotonic() - began
+    waiter.join(10)
+
+    assert errors and "busy" in errors[0]
+    assert "send_ctrl_break" in errors[0]
+    # It must fail fast, not sit out its own 60s timeout: this call is made from
+    # the server's event loop, so waiting here would stall every other session -
+    # and the send_ctrl_break the message recommends.
+    assert elapsed < 1
+
+
+def test_output_landing_at_the_deadline_is_not_thrown_away(make_session, monkeypatch):
+    """The bugcheck banner is the most valuable thing a kernel session ever
+    prints; it must not be lost for arriving a microsecond after the deadline."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+
+    real_wait = session.ready_event.wait
+
+    def _wait_then_deliver(timeout=None):
+        # Report the deadline as missed, but only after the target has in fact
+        # stopped and the reader has published - the exact race being guarded.
+        real_wait(0.05)
+        proc.target_stops("*** Fatal System Error: 0x0000007e")
+        real_wait(0.5)
+        return False
+
+    monkeypatch.setattr(session.ready_event, "wait", _wait_then_deliver)
+    out = session.wait_for_break(timeout=1)
+    assert any("Fatal System Error" in line for line in out)
+
+
+def test_a_timed_out_command_still_reports_why_the_target_stopped(make_session):
+    session, proc = make_session(timeout=3, live=True)
+    session.send_command("g")
+    proc.target_stops("*** Fatal System Error: 0x0000007e")
+    # Answer the break-in probe, then hang: only the command times out.
+    proc.answer_budget = 1
+    with pytest.raises(DebuggerError) as exc:
+        session.send_command("!analyze -v", timeout=1)
+    assert "Fatal System Error" in str(exc.value)
+
+
+def test_resume_after_ctrl_break_is_allowed(make_session):
+    """send_ctrl_break leaves _target_running set on purpose; that must not make
+    the resume it tells you about impossible."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    session.send_ctrl_break()
+    out = session.send_command("g")
+    assert any("resumed" in line.lower() for line in out)
+    assert proc.running is True
+
+
+def test_a_breakpoint_before_a_go_reports_whether_it_was_set(make_session):
+    """'bp X; g' is one line to the caller but two things to the session: the
+    breakpoint's result is the difference between a wait that can end and one
+    that cannot."""
+    session, proc = make_session(live=True)
+    out = session.send_command("bp nt!NtCreateFile; g")
+    assert "OUT:bp nt!NtCreateFile" in out
+    assert any("resumed" in line.lower() for line in out)
+    assert proc.running is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'bp nt!NtCreateFile ".echo hit; g;"',   # the '; g' is the breakpoint's own
+        'bp X "kb; g "',
+        '.echo "a; gc b"',
+    ],
+)
+def test_a_go_inside_a_quoted_command_string_is_not_a_resume(command):
+    assert DebuggerSession._is_go_command(command) is False
+
+
+def test_closing_a_session_ends_a_parked_wait(make_session):
+    """Otherwise a worker thread sits on a dead debugger for the rest of its
+    timeout, and the caller is told the target is still running."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+
+    outcome: list = []
+    started = threading.Event()
+
+    def _wait():
+        started.set()
+        try:
+            outcome.append(session.wait_for_break(timeout=30))
+        except DebuggerError as exc:
+            outcome.append(exc)
+
+    waiter = threading.Thread(target=_wait, daemon=True)
+    waiter.start()
+    started.wait()
+    time.sleep(0.2)
+    began = time.monotonic()
+    session.shutdown()
+    waiter.join(10)
+    assert time.monotonic() - began < 5
+    assert isinstance(outcome[0], DebuggerError)
+    assert "closed" in str(outcome[0])
+
+
+def test_resume_after_ctrl_break_reports_why_the_target_had_stopped(make_session):
+    """The break banner must ride out on the resume, not be stranded in the
+    session for the next operation to wipe."""
+    session, proc = make_session(live=True)
+    session.send_command("g")
+    session.send_ctrl_break()
+    out = session.send_command("g")
+    assert any("Break instruction exception" in line for line in out)
+    assert any("resumed" in line.lower() for line in out)
+
+
+def test_a_timed_out_prefix_still_reports_why_the_target_stopped(make_session):
+    """The 'bp X; g' path has its own preamble to lose."""
+    session, proc = make_session(timeout=3, live=True)
+    session.send_command("g")
+    proc.target_stops("*** Fatal System Error: 0x0000007e")
+    proc.answer_budget = 1  # answer the break-in probe, then hang
+    with pytest.raises(DebuggerError) as exc:
+        session.send_command("bp nt!NtCreateFile; g", timeout=1)
+    assert "Fatal System Error" in str(exc.value)

--- a/src/mcp_windbg/tests/test_kd_session.py
+++ b/src/mcp_windbg/tests/test_kd_session.py
@@ -187,12 +187,23 @@ def test_init_raises_when_kd_not_found(monkeypatch):
         KDSession(kernel_connection="net:port=50005,key=1.2.3.4")
 
 
-def test_on_output_line_sets_connected_event_only_on_banner():
+@pytest.mark.parametrize(
+    "banner",
+    [
+        # KDNET
+        "Connected to target 10.0.0.5 on port 50005 on local IP 10.0.0.1.",
+        # Named pipe / serial. Matching only the KDNET wording made every
+        # pipe-connected session time out in _startup (#47).
+        "Kernel Debugger connection established.",
+    ],
+)
+def test_on_output_line_sets_connected_event_only_on_banner(banner):
     obj = KDSession.__new__(KDSession)
     obj._connected_event = __import__("threading").Event()
     obj._on_output_line("Waiting to reconnect...")
+    obj._on_output_line("Opened \\\\.\\pipe\\com_1")
     assert not obj._connected_event.is_set()
-    obj._on_output_line("Connected to target 10.0.0.5 on port 50005 on local IP 10.0.0.1.")
+    obj._on_output_line(banner)
     assert obj._connected_event.is_set()
 
 


### PR DESCRIPTION
Fixes #71, #72, #73. Supersedes #74.

@TempAccountNull diagnosed all three bugs correctly. This keeps every fix and the credit, but replaces the patch - it had a defect that would have broken stepping - and adds one more bug found by backtesting against a real kernel target.

## The three reported bugs

- **Named pipe / COM sessions always timed out** (#71). `kd` announces a pipe or serial link with `Kernel Debugger connection established`, not the KDNET `Connected to target ...`. Only the latter was matched, so `open_kd_session` sat waiting for a banner that was never coming on a target that had in fact attached.
- **`g` re-froze the target it had just released** (#72). Go-class commands hand the CPU back and the debugger stops reading stdin, so the marker protocol's `.echo` sat unread, the command hit its timeout, and the cancel-on-timeout CTRL+BREAK halted the machine again.
- **Any command after `g` did the same** (#73), through the same path - the session had no concept of "the target is running".

## Why #74 is not merged as-is

Its `_GO_COMMANDS` set includes `p`, `t`, `pa`, `ta`. Those are *step* commands: they execute one instruction or line and come straight back to the prompt. Treating them as fire-and-forget swallows their output, returns `"Target resumed."` instead, and leaves the session believing the target is running - so the next command fires a spurious CTRL+BREAK. Stepping would have become unusable. The step family keeps the marker round-trip here, with a test pinning it.

## The fourth bug, found by backtesting

`_resume_target` wrote `g` and returned immediately. Until `kd` reads it, `kd` is still at its prompt with the resume unread - and a CTRL+BREAK arriving in that window is answered by the prompt rather than reaching the target. The break is silently lost and the caller then waits out a full `wait_for_break` timeout on a machine nothing will stop.

That is exactly the sequence a tool caller writes, because `run_kd_command("g")` now returns instantly. Measured on the live KDNET target:

| gap after `g` | result |
| :--- | :--- |
| 0.00s | **break lost** (every attempt) |
| 0.05s | landed in 0.04s |
| 0.25s / 1s / 2s | landed |

The resume is now probed with a marker the debugger can only answer from a prompt. Silence means it stopped reading stdin - the target is away and the resume can no longer swallow a break. An answer means the target never left, which is a bonus fix: a `gu` that returns in microseconds, or a breakpoint hit at once, now reports what it printed instead of falsely claiming the target is running.

## Also in here

- `wait_for_break` - block until a target stops (bugcheck, breakpoint, manual break) and return what it printed. Asks the debugger rather than trusting a flag, so it is right about targets this server never resumed. If the wait expires the target is left **running**.
- Compound forms: `bp nt!X; g` runs the breakpoint first and returns its result, so a typo'd symbol surfaces as `Couldn't resolve error` rather than a 300s wait for a break that can never come. A `;` inside a quoted command string is left alone.
- Qualified forms `~0 g` / `~*g` are recognized.
- One operation at a time per session; closing a session ends a wait parked on it.

## Verification

Against the real kernel target (Windows 11 26100, KDNET):

- `scenarios/kernel_resume_and_wait.yaml` - new, covers resume, auto break-in, and the zero-gap break. **Verified to fail without the fix** with exactly the lost-break symptom, and to pass with it.
- `scenarios/kernel_session.yaml` - still passes.
- Machine confirmed left running afterwards, with no breakpoints behind.

Hermetic and user-mode:

- 89 hermetic tests pass (was 29 on `main`).
- 10 `live` user-mode scenarios pass, including the new `resume_and_wait.yaml` against a real `cdb.exe`.
- Coverage 91% under CI's conditions, against the 88% gate.
- `mkdocs build --strict` clean; `docs/reference/tools.md` documents the resume semantics.

**One limitation worth stating:** #71 is the one fix I could not exercise end to end - this box has a KDNET target, not a pipe one. It is covered hermetically for both banner wordings, and I did capture `Kernel Debugger connection established.` verbatim from real `kd` output during a KDNET reconnect, so the string is genuine. That it appears *instead of* the KDNET wording on a pipe transport rests on @TempAccountNull's report and their verified before/after.