### PR TITLE
chore: prepare the 1.1.0 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!--
+The PR title becomes the commit subject when this is squash-merged, and that
+subject is what drives the next release. Please make it a Conventional Commit:
+
+  feat: ...      new capability          -> minor version bump
+  fix: ...       bug fix                 -> patch
+  perf: / docs: / deps: ...              -> patch, listed in the release notes
+  chore: / ci: / test: / refactor: ...   -> not listed in the release notes
+  feat!: ...     or a BREAKING CHANGE:   -> major
+
+A title with no prefix contributes nothing to the next version, so the change
+can end up shipping unannounced. Scopes are welcome: fix(kernel): ...
+
+Nothing else in this template is required - delete what does not apply.
+-->
+
+## What this changes
+
+## Why
+
+## How it was verified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-08-22
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,19 @@ A title with no recognized prefix contributes nothing. If everything since the l
 hidden-only (`chore`, `ci`, `test`, ...), release-please opens no release PR at all - by design,
 not a failure. `Release-As: X.Y.Z` in a commit body forces an exact version.
 
+**When no release PR appears and you expected one**, read the `release-please` job log. It says
+which commits it could use:
+
+```
+commit could not be parsed: 30c7dd9 Fix kernel go/break-in handling, add wait_for_break (#80)
+Considering: 1 commits
+No user facing commits found since c7ae1a6 - skipping
+```
+
+`could not be parsed` means the subject was not a Conventional Commit, so it counted for nothing.
+`No user facing commits found` means everything that did parse was a hidden type. Neither is an
+error; both mean there is nothing to release yet.
+
 **The flow.** Every push to `main` runs `release-please.yml`, which opens or rewrites a
 `chore(main): release X.Y.Z` PR carrying the version bumps. Before merging it, **add the
 `CHANGELOG.md` entry to that PR**: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` to match


### PR DESCRIPTION
Sets up the first release through the new release-please flow, and closes two gaps in it.

## Changelog

Promotes `## [Unreleased]` to `## [1.1.0] - 2026-08-22`. With `skip-changelog` this file is ours to maintain, and the version-consistency check on the release build compares its top heading against `pyproject.toml` - so it has to say 1.1.0 before release-please sets that version.

Verified the `release-notes` job's extractor pulls the right section: 79 lines, starting at "Runs on the mcp 2.x SDK".

## Pull request template

The release flow now depends on something an outside contributor has no way to know: squash-merging makes the PR title the commit subject, and that subject decides the next version. CLAUDE.md covers it for anyone working in the repo, but nobody opening their first PR reads CLAUDE.md. The template says it in the one place they will see.

Not hypothetical - of the last several merges here, only `fix(deps): pin mcp dependency to <2.0.0` had a title that counted.

## Troubleshooting note

The first release-please run on `main` produced no release PR, which is correct but reads like a failure. CLAUDE.md now records what the log actually says:

```
commit could not be parsed: 30c7dd9 Fix kernel go/break-in handling, add wait_for_break (#80)
Considering: 1 commits
No user facing commits found since c7ae1a6 - skipping
```

`could not be parsed` = the subject was not a Conventional Commit and counted for nothing. `No user facing commits found` = everything that parsed was a hidden type.

## Release-As

This PR must be squash-merged with `Release-As: 1.1.0` in the commit body. Without it release-please would see only `chore:` (hidden) since v1.0.1 and open no release PR at all - the work in 1.1.0 landed under titles it cannot read.

After merge: release-please opens the release PR bumping `pyproject.toml` and `server.json` to 1.1.0; merging that cuts the tag, sets the release body from this changelog entry, and publishes to PyPI.