### PR TITLE
ci: restore the server.json extra-files entries

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,11 @@
   "packages": {
     ".": {
       "package-name": "mcp-windbg",
-      "skip-changelog": true
+      "skip-changelog": true,
+      "extra-files": [
+        { "type": "json", "path": "server.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "server.json", "jsonpath": "$.packages[*].version" }
+      ]
     }
   }
 }


### PR DESCRIPTION
Caught by inspecting the first real release PR (#84) rather than trusting it: it bumped `pyproject.toml` and `.release-please-manifest.json` to 1.1.0 but left all three `server.json` versions at 1.0.1.

Cause: the `extra-files` block was dropped when the config was switched to `skip-changelog`.

`scripts/check-version-consistency.ps1` on the release build would have caught this - but only after the tag and GitHub release already existed, which is exactly the late-failure mode described in CLAUDE.md.

Two entries are needed because `server.json`'s top-level `version` and the two `packages[*].version` fields are separate, and one entry carries one JSONPath. Two entries against the same path are applied in sequence rather than clobbering each other, and the wildcard covers both array elements.

Once this lands, release-please rewrites #84 and `server.json` should appear in its diff. I will confirm that before merging the release.