### PR TITLE
ci: allow release-please to be re-run by hand

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,11 @@ on:
   push:
     branches:
       - main
+  # Rebuild the release PR on demand. release-please leaves an open release PR
+  # alone when the version it computes has not changed, so a config fix that
+  # only alters the PR's *contents* is not picked up on its own - delete the
+  # release branch and run this to have it rebuilt.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,16 @@ No user facing commits found since c7ae1a6 - skipping
 `No user facing commits found` means everything that did parse was a hidden type. Neither is an
 error; both mean there is nothing to release yet.
 
+**A config change does not rewrite an open release PR.** release-please leaves an existing
+release PR alone when the version it computes has not changed, so fixing something that only
+affects the PR's *contents* - an `extra-files` entry, say - has no visible effect. Delete the
+`release-please--branches--main--*` branch (which closes the PR) and re-run the workflow from the
+Actions tab via `workflow_dispatch`; it rebuilds the PR with the new config.
+
+**Check the release PR's diff before merging it.** It should touch `pyproject.toml`,
+`.release-please-manifest.json`, and all three versions in `server.json`. A missing `server.json`
+means the `extra-files` entries are not firing.
+
 **The flow.** Every push to `main` runs `release-please.yml`, which opens or rewrites a
 `chore(main): release X.Y.Z` PR carrying the version bumps. Before merging it, **add the
 `CHANGELOG.md` entry to that PR**: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` to match


### PR DESCRIPTION
Adds `workflow_dispatch` to `release-please.yml`, and documents the gotcha that made it necessary.

## What happened

#85 restored the `server.json` `extra-files` entries, but the already-open 1.1.0 release PR did not change. release-please leaves an existing release PR alone when the version it computes has not moved, so a fix that only affects the PR's *contents* is invisible: the branch had been built by the earlier run and was never rebuilt.

Recovering means deleting the release branch to force a fresh build - and with `on: push` as the only trigger, the only way to start that build was to push another commit to `main`. This makes it a button.

## Also in CLAUDE.md

- An open release PR is not rewritten by a config change; delete the `release-please--branches--main--*` branch and re-run via `workflow_dispatch`.
- **Check the release PR's diff before merging.** It should touch `pyproject.toml`, `.release-please-manifest.json`, and all three versions in `server.json`. A missing `server.json` means `extra-files` is not firing - which is exactly how the bug in #85 was found, and the check-version guard would only have caught it after the tag and release already existed.