### PR TITLE
ci: release from develop and fast-forward main onto each release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main, master ]
+    branches: [ develop, main, master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,9 @@ on:
       - mkdocs.yml
       - requirements-docs.txt
       - .github/workflows/pages.yml
+  # Called by release-please.yml once main has been fast-forwarded onto a
+  # release. That push is made with GITHUB_TOKEN and so triggers nothing itself.
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,23 +2,27 @@ name: Release Please
 
 # Release automation, in two phases that both run from this one file.
 #
-# 1. Every push to main, release-please recomputes what the next version would
-#    be from the Conventional Commit subjects since the last release, and opens
-#    or rewrites a "chore(main): release X.Y.Z" PR carrying the version bumps
-#    and the CHANGELOG entry.
-# 2. Merging that PR pushes to main, which runs this workflow again. This time
-#    release-please sees a merged release PR, creates the tag and the GitHub
-#    release, and the publish job below ships it to PyPI.
+# Work lands on develop. main is moved only by this workflow, so it always
+# equals the last released commit.
 #
-# The publish job lives in this same workflow on purpose. A release created with
-# the default GITHUB_TOKEN does not trigger other workflows, so the old
-# `on: push: tags: [v*]` publish would silently never fire. Calling it via
-# `needs` sidesteps that entirely - no cross-workflow trigger is involved.
+# 1. Every push to develop, release-please recomputes what the next version
+#    would be from the Conventional Commit subjects since the last release, and
+#    opens or rewrites a "chore(develop): release X.Y.Z" PR carrying the version
+#    bumps and the CHANGELOG entry.
+# 2. Merging that PR pushes to develop, which runs this workflow again. This
+#    time release-please sees a merged release PR and creates the tag and the
+#    GitHub release. The jobs below then fast-forward main onto that commit,
+#    ship to PyPI, and publish the docs.
+#
+# Everything downstream lives in this same workflow on purpose. A release - or a
+# push - made with the default GITHUB_TOKEN does not trigger other workflows, so
+# an `on: push: tags` publish, or a pages build watching main, would silently
+# never fire. Calling them through `needs` sidesteps that entirely.
 
 on:
   push:
     branches:
-      - main
+      - develop
   # Rebuild the release PR on demand. release-please leaves an open release PR
   # alone when the version it computes has not changed, so a config fix that
   # only alters the PR's *contents* is not picked up on its own - delete the
@@ -41,12 +45,18 @@ jobs:
       # expression, so a bare `if: ...outputs.releases_created` is always true.
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      # The release commit on develop. main is fast-forwarded onto exactly this.
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Without this release-please works against the repository's default
+          # branch. That is develop today, but stating it keeps this workflow
+          # correct if the default is ever changed back.
+          target-branch: develop
           # Releases and PRs made with GITHUB_TOKEN do not trigger workflows, so
           # CI does not run on the release PR itself. Supply a PAT or GitHub App
           # token here if you want the PR gated by the test matrix before merge.
@@ -94,3 +104,42 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish-mcp.yml
     secrets: inherit
+
+  # main is a pointer to the last released commit, moved only from here. This is
+  # a plain fast-forward, so it fails loudly rather than rewriting anything if
+  # main carries commits develop does not - which happens only if someone pushed
+  # to main directly.
+  fast-forward-main:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward main onto the released commit
+        env:
+          SHA: ${{ needs.release-please.outputs.sha }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          if git push origin "$SHA:refs/heads/main"; then
+            echo "main now points at $SHA ($TAG)."
+          else
+            echo "::error::Could not fast-forward main onto $SHA ($TAG). main has commits that develop does not; merge main into develop and re-run this workflow."
+            exit 1
+          fi
+
+  # Docs describe the released version, so they publish from a release rather
+  # than from every push. Chained rather than triggered: the fast-forward above
+  # is a GITHUB_TOKEN push and so does not start pages.yml on its own.
+  docs:
+    needs: [release-please, fast-forward-main]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/pages.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,13 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 not bump versions and you do not push tags. You **do** still write `CHANGELOG.md` by hand: it is
 configured with `skip-changelog`, so release-please never touches it.
 
+**Branches.** `develop` is the working branch and the base for every `feat/*` and `fix/*` PR;
+it is the repository default, so PRs and Dependabot target it automatically. `main` is not a
+branch you commit to - `release-please.yml` fast-forwards it onto each released commit, so it
+always equals the last released state. Never push to `main` directly: the fast-forward is a
+plain one, so a commit on `main` that `develop` lacks fails the next release until someone
+merges `main` back into `develop` by hand.
+
 **PR titles decide the version.** Because PRs are squash-merged, the PR title becomes the commit
 subject, which is what release-please reads. It must be a Conventional Commit:
 
@@ -136,24 +143,31 @@ error; both mean there is nothing to release yet.
 **A config change does not rewrite an open release PR.** release-please leaves an existing
 release PR alone when the version it computes has not changed, so fixing something that only
 affects the PR's *contents* - an `extra-files` entry, say - has no visible effect. Delete the
-`release-please--branches--main--*` branch (which closes the PR) and re-run the workflow from the
-Actions tab via `workflow_dispatch`; it rebuilds the PR with the new config.
+`release-please--branches--develop--*` branch (which closes the PR) and re-run the workflow
+from the Actions tab via `workflow_dispatch`; it rebuilds the PR with the new config.
 
 **Check the release PR's diff before merging it.** It should touch `pyproject.toml`,
 `.release-please-manifest.json`, and all three versions in `server.json`. A missing `server.json`
 means the `extra-files` entries are not firing.
 
-**The flow.** Every push to `main` runs `release-please.yml`, which opens or rewrites a
-`chore(main): release X.Y.Z` PR carrying the version bumps. Before merging it, **add the
+**The flow.** Every push to `develop` runs `release-please.yml`, which opens or rewrites a
+`chore(develop): release X.Y.Z` PR carrying the version bumps. Before merging it, **add the
 `CHANGELOG.md` entry to that PR**: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` to match
-the version in the PR title. Merging pushes to `main`, which runs the workflow again; this time
-release-please creates the tag and the GitHub release, `release-notes` replaces the generated
-notes with your CHANGELOG entry, and `publish` calls `publish-mcp.yml` to run the full test
-matrix and ship to PyPI.
+the version in the PR title. Merging that PR is what "release now" means. It pushes to `develop`,
+which runs the workflow again; this time release-please creates the tag and the GitHub release,
+and then, in the same run:
+
+- `release-notes` replaces the generated notes with your CHANGELOG entry.
+- `fast-forward-main` pushes `main` to the released commit.
+- `publish` calls `publish-mcp.yml` to run the full test matrix and ship to PyPI.
+- `docs` calls `pages.yml` to deploy the documentation site.
+
+The last two are chained through `needs` rather than triggered, for the `GITHUB_TOKEN` reason
+below: neither the tag nor the `main` fast-forward starts a workflow on its own.
 
 Forgetting the CHANGELOG entry is caught, but late: `scripts/check-version-consistency.ps1` runs
 on the release build and fails when the top `## [x.y.z]` heading does not match `pyproject.toml`.
-The tag and release will already exist, so fix the CHANGELOG on `main` and re-run
+The tag and release will already exist, so fix the CHANGELOG on `develop` and re-run
 `publish-mcp.yml` by hand via `workflow_dispatch`.
 
 **What release-please keeps in sync.** `release-please-config.json` drives it. The `python`
@@ -168,8 +182,10 @@ entry carries one JSONPath.
   must stay enabled, or opening the release PR fails with a 403.
 - Releases created with the default `GITHUB_TOKEN` do not trigger other workflows. That is why
   `publish-mcp.yml` is `workflow_call`/`workflow_dispatch` rather than `on: push: tags` - a tag
-  trigger would silently never fire. It is also why CI does not run on the release PR itself;
-  supply a PAT or GitHub App token to `release-please.yml` if you want that gate.
+  trigger would silently never fire. The same applies to the `main` fast-forward, which is why
+  `pages.yml` gained a `workflow_call` trigger instead of watching `main`. It is also why CI does
+  not run on the release PR itself; supply a PAT or GitHub App token to `release-please.yml` if
+  you want that gate.
 
 ## Docs
 


### PR DESCRIPTION
Moves the release process to a `main <- develop <- feat/fix` model.

`develop` is now the repository default and the base for every feature and fix PR. release-please watches it and keeps a `chore(develop): release X.Y.Z` PR open there; merging that PR is what "release now" means. `main` stops being a branch anyone commits to and becomes a pointer to the last released commit.

## What changed

| File | Change |
| :--- | :----- |
| `release-please.yml` | Triggers on `develop`, `target-branch: develop`, new `fast-forward-main` and `docs` jobs |
| `pages.yml` | Gains a `workflow_call` trigger |
| `ci.yml` | Runs on pushes to `develop` |
| `CLAUDE.md` | Release section rewritten for the two-branch flow |

## The GITHUB_TOKEN trap, twice

This repo already calls `publish-mcp.yml` through `needs` rather than from `on: push: tags`, because a release created with the default `GITHUB_TOKEN` does not trigger other workflows.

The `main` fast-forward is the same kind of push and hits the same wall. A `pages.yml` left watching `main` would therefore have gone quiet forever after this change - docs would simply have stopped deploying, with nothing failing to say so. So `pages.yml` gets a `workflow_call` trigger and is chained from the release run instead. Its `push: main` trigger is kept as a manual escape hatch.

## Failure mode worth knowing

`fast-forward-main` does a plain `git push origin <sha>:refs/heads/main`. If someone pushes to `main` directly, that push stops fast-forwarding and the job fails with an explicit error naming the fix (merge `main` into `develop`, re-run). It never force-pushes, so a divergence is reported rather than silently discarded.

`main` is currently unprotected, which is what lets the workflow move it with the default token. A ruleset restricting pushes to the workflow would be a sensible follow-up, but it needs a bypass actor configured correctly or it blocks the very job that advances `main` - worth doing after one release has been observed working.

## Verification

- All seven workflow files parse as YAML.
- Docs typography check clean.
- Release-notes `awk` block, `publish` job, and `release-please-config.json` are untouched.