### PR TITLE
fix(plugin): stop the crash-analyst agent hard-coding the plugin name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `crash-analyst` agent no longer hard-codes the plugin's installed name** - its `tools:`
+  list named MCP tools as `mcp__plugin_mcp-windbg_mcp-windbg__*`, and that middle segment is the
+  name the plugin is installed under. Under any marketplace entry not called exactly
+  `mcp-windbg` the list would have matched nothing, leaving the agent with no debugger tools at
+  all. It now denies the mutating tools instead, which keeps it read-only without naming the
+  plugin.
+
 ### Added
 
 - **A Claude Code plugin, and a marketplace to serve it from this repo** - installing is now two

--- a/plugins/mcp-windbg/agents/crash-analyst.md
+++ b/plugins/mcp-windbg/agents/crash-analyst.md
@@ -1,7 +1,12 @@
 ---
 name: crash-analyst
 description: Deep-dive a Windows crash dump and return a written verdict. Use when a dump needs more than a first look - several hypotheses to rule out, many frames or threads to walk, or a conclusion someone will act on. Give it the dump path and the question.
-tools: mcp__plugin_mcp-windbg_mcp-windbg__list_dumps, mcp__plugin_mcp-windbg_mcp-windbg__open_cdb_dump, mcp__plugin_mcp-windbg_mcp-windbg__run_cdb_command, mcp__plugin_mcp-windbg_mcp-windbg__close_cdb_session, Read, Grep, Glob
+# Deliberately not a `tools:` allow-list. An MCP tool's name embeds the name the
+# plugin is installed under (mcp__plugin_<plugin>_<server>__<tool>), so naming
+# them here would leave this agent with a list matching nothing under any
+# marketplace entry not called exactly "mcp-windbg". Denying the mutating tools
+# instead keeps it read-only without hard-coding that name.
+disallowedTools: Write, Edit, NotebookEdit, Bash
 ---
 
 # Crash analyst


### PR DESCRIPTION
The `crash-analyst` agent listed its MCP tools in full:

```
tools: mcp__plugin_mcp-windbg_mcp-windbg__list_dumps, ... , Read, Grep, Glob
```

That middle segment, `mcp-windbg`, is **the name the plugin is installed under** - a marketplace entry name, not a fixed string. It works today because there is one entry and it happens to be called `mcp-windbg`. The moment a second entry exists (`mcp-windbg-uvx` alongside a self-contained `mcp-windbg`, for instance) the list matches nothing on that entry, and the agent runs with no debugger tools at all.

That is a worse failure than over-permissioning: the agent still starts, still gets asked to analyse a dump, and confidently reports on nothing.

## Why not a narrower allow-list

There is no way to name an MCP tool without that segment - `mcp__<server>` and `mcp__<server>__*` still resolve through the same scoped server name. An allow-list therefore cannot be made independent of the installed name. So the restriction is expressed the other way round:

```yaml
disallowedTools: Write, Edit, NotebookEdit, Bash
```

This achieves the actual intent - a read-only investigator - without naming the plugin anywhere.

## The trade

The agent now inherits the kernel and remote tools it previously lacked (`open_kd_session`, `send_ctrl_break`, and so on). Its prompt scopes it to a single dump, and it can no longer write files or run shell commands, but this is a genuine widening and worth stating rather than glossing over. The alternative - regenerating the agent file per marketplace entry at build time - keeps the tighter list but means the repo copy and the packaged copy differ, which is its own maintenance cost.

## Verification

Installed from the repo marketplace and checked the component inventory:

```
Skills (4)  analyze-dump, debug-remote, kernel-debug, windbg-doctor
Agents (1)  crash-analyst
MCP servers (1)  mcp-windbg
```

The agent still registers and the frontmatter parses with the explanatory YAML comments in place. Local test state was removed afterwards.