### PR TITLE
ci: gate the release on every version and the CHANGELOG agreeing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,35 @@ permissions:
   contents: read
 
 jobs:
+  # The last moment before a tag exists. release-please creates the tag and the
+  # GitHub release in a single step, so anything asserted after it - as the
+  # version-consistency check was, from the publish job - reports a problem that
+  # has already shipped and needs a second release to correct. Everything that
+  # must be true of a release is therefore asserted here, and release-please does
+  # not run unless it holds.
+  #
+  # Only a release merge is checked. On an ordinary push CHANGELOG.md carries a
+  # `## [Unreleased]` heading, which is correct there and would fail the version
+  # comparison, so the check would cry wolf on every commit.
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Assert every version and the CHANGELOG agree
+        shell: pwsh
+        run: |
+          $subject = git log -1 --pretty=%s
+          if ($subject -notmatch '^chore\(develop\): release ') {
+            Write-Host "Not a release merge - nothing to assert."
+            Write-Host "  head commit: $subject"
+            exit 0
+          }
+          Write-Host "Release merge detected: $subject"
+          ./scripts/check-version-consistency.ps1
+
   release-please:
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: write        # tags, releases, and the release branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,10 +165,17 @@ and then, in the same run:
 The last two are chained through `needs` rather than triggered, for the `GITHUB_TOKEN` reason
 below: neither the tag nor the `main` fast-forward starts a workflow on its own.
 
-Forgetting the CHANGELOG entry is caught, but late: `scripts/check-version-consistency.ps1` runs
-on the release build and fails when the top `## [x.y.z]` heading does not match `pyproject.toml`.
-The tag and release will already exist, so fix the CHANGELOG on `develop` and re-run
-`publish-mcp.yml` by hand via `workflow_dispatch`.
+Forgetting the CHANGELOG entry fails the release before it happens. The `preflight` job runs
+`scripts/check-version-consistency.ps1` ahead of release-please whenever the head commit is a
+`chore(develop): release ...` merge, and release-please does not run unless it passes. It asserts
+that `pyproject.toml`, both versions in `server.json`, `.release-please-manifest.json`, the plugin
+manifest, the marketplace entry and the `uvx` pin in the plugin's `.mcp.json` all carry the same
+version, that `CHANGELOG.md`'s top heading names it, and that the heading has an entry under it.
+No tag is created when any of that is wrong, so the fix is a commit to `develop` rather than a
+second release.
+
+The same script still runs from the publish build, which is what guards a `publish-mcp.yml`
+started by hand.
 
 **What release-please keeps in sync.** `release-please-config.json` drives it. The `python`
 release type updates `pyproject.toml`'s `[project] version` natively. `server.json` is not

--- a/scripts/check-version-consistency.ps1
+++ b/scripts/check-version-consistency.ps1
@@ -1,11 +1,16 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Checks version consistency between pyproject.toml, server.json, and CHANGELOG.md
+    Checks that every version in the repository, and the CHANGELOG entry, agree
 
 .DESCRIPTION
-    This script extracts version information from pyproject.toml, server.json, and CHANGELOG.md
-    and verifies that all versions are consistent across these files.
+    Extracts the version from pyproject.toml, server.json (top level and package),
+    .release-please-manifest.json, the Claude plugin manifest, the marketplace entry and the
+    server version pinned in the plugin's .mcp.json, and checks they all match. Also checks that
+    CHANGELOG.md's top heading names that version and has an entry underneath it.
+
+    Run as a gate before release-please creates a tag: everything it asserts is something that
+    cannot be fixed after a release without publishing a second one.
 
 .EXAMPLE
     .\check-version-consistency.ps1
@@ -54,6 +59,22 @@ try {
     }
     $CHANGELOG_VERSION = $changelogMatch.Matches[0].Groups[1].Value
     Write-Host "INFO: CHANGELOG.md version: $CHANGELOG_VERSION" -ForegroundColor Green
+
+    # A heading on its own still matches the version but leaves release-notes with nothing to
+    # publish, so read what sits under it, up to the next heading. LineNumber is 1-based and the
+    # array is 0-based, so indexing with it starts on the line after the heading.
+    $changelogLines = Get-Content "CHANGELOG.md"
+    $entryBody = @()
+    for ($i = $changelogMatch.LineNumber; $i -lt $changelogLines.Count; $i++) {
+        if ($changelogLines[$i].StartsWith("## [")) { break }
+        $entryBody += $changelogLines[$i]
+    }
+    $CHANGELOG_EMPTY = -not ($entryBody | Where-Object { $_.Trim() })
+
+    # The version release-please itself tracks. If this drifts from pyproject.toml the next
+    # release is computed from the wrong base.
+    $MANIFEST_VERSION = (Get-Content ".release-please-manifest.json" -Raw | ConvertFrom-Json).'.'
+    Write-Host "INFO: .release-please-manifest.json version: $MANIFEST_VERSION" -ForegroundColor Green
     
     # Extract versions from the Claude plugin + marketplace manifests. These are
     # kept in step by release-please extra-files entries; checking them here is
@@ -91,6 +112,14 @@ try {
     
     if ($PYPROJECT_VERSION -ne $CHANGELOG_VERSION) {
         $errors += "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != CHANGELOG.md ($CHANGELOG_VERSION)"
+    }
+
+    if ($PYPROJECT_VERSION -ne $MANIFEST_VERSION) {
+        $errors += "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != .release-please-manifest.json ($MANIFEST_VERSION)"
+    }
+
+    if ($CHANGELOG_EMPTY) {
+        $errors += "CHANGELOG.md has a '## [$CHANGELOG_VERSION]' heading with nothing under it - the release notes would be empty"
     }
     
     if ($errors.Count -gt 0) {


### PR DESCRIPTION
Makes `check-version-consistency.ps1` a gate instead of a post-mortem.

It ran from the publish build - which is *after* release-please has created the tag and the GitHub release. It reported problems that had already shipped, and the only way to correct one was to cut a second release. CLAUDE.md described this as "caught, but late".

It now runs as a `preflight` job that `release-please` depends on, so a release that is not internally consistent never gets a tag.

## What is asserted

All seven version sources must carry the same version:

| Source | Kept in step by |
| :----- | :-------------- |
| `pyproject.toml` | release-please, natively |
| `server.json` top level and `packages[*]` | two `extra-files` entries |
| `.release-please-manifest.json` | release-please, natively |
| `plugins/mcp-windbg/.claude-plugin/plugin.json` | `extra-files` |
| `.claude-plugin/marketplace.json` | `extra-files` |
| the `uvx` pin in the plugin `.mcp.json` | `extra-files` |

Plus: `CHANGELOG.md`s top heading names that version, **and has an entry under it**.

## Two assertions added while promoting it

- **`.release-please-manifest.json`** was unchecked. It is the version release-please computes the *next* release from, so drift there silently misprices the following release rather than the current one.
- **A bare heading**. `## [1.2.0]` with nothing beneath it matched the version comparison perfectly and published empty release notes. The `release-notes` job could only emit a warning about it, after the release existed.

## Why only release merges are checked

On an ordinary push `CHANGELOG.md` correctly carries `## [Unreleased]`, which would fail the version comparison on every single commit. The job therefore reads the head commit subject and only enforces on `chore(develop): release ...`. Verified against real subjects:

```
CHECK  <- chore(develop): release 1.2.0 (#91)
SKIP   <- fix(plugin): stop the agent hard-coding (#92)
SKIP   <- chore(main): release 1.2.0 (#89)
```

## Verification

Three states, exit codes checked directly rather than through a pipe:

| State | Expected | Got |
| :---- | :------- | :-- |
| Today`s tree, `## [Unreleased]` on top | fail | exit 1, names the mismatch |
| Simulated 1.2.0 release, all seven sources bumped | pass | exit 0 |
| 1.2.0 heading with an empty body | fail | exit 1, names the empty section |

The script still runs from the publish build as well, which is what guards a `publish-mcp.yml` started by hand.