### PR TITLE
feat(plugin): name the marketplace entry by how it ships

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,8 @@
   "description": "Windows crash dump analysis and live WinDbg debugging for Claude Code.",
   "plugins": [
     {
-      "name": "mcp-windbg",
+      "name": "mcp-windbg-uvx",
+      "displayName": "WinDbg (uv)",
       "source": "./plugins/mcp-windbg",
       "description": "Analyze Windows crash dumps and drive live user-mode or kernel debugging through WinDbg/CDB. Windows only; needs CDB and uv.",
       "version": "1.1.0",
@@ -18,7 +19,15 @@
       "homepage": "https://svnscha.github.io/mcp-windbg/",
       "repository": "https://github.com/svnscha/mcp-windbg",
       "license": "MIT",
-      "keywords": ["debugging", "windbg", "cdb", "kd", "crash-dump", "kernel", "windows"],
+      "keywords": [
+        "debugging",
+        "windbg",
+        "cdb",
+        "kd",
+        "crash-dump",
+        "kernel",
+        "windows"
+      ],
       "category": "development"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "mcp-windbg-uvx",
-      "displayName": "WinDbg (uv)",
+      "displayName": "MCP for WinDbg (uvx version)",
       "source": "./plugins/mcp-windbg",
       "description": "Analyze Windows crash dumps and drive live user-mode or kernel debugging through WinDbg/CDB. Windows only; needs CDB and uv.",
       "version": "1.1.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ```
   /plugin marketplace add svnscha/mcp-windbg
-  /plugin install mcp-windbg@mcp-windbg
+  /plugin install mcp-windbg-uvx@mcp-windbg
   ```
 
   The plugin launches the server with `uvx`, which fetches the pinned version from PyPI on first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,18 @@ matching file:
 Tool and CLI facts come from `src/mcp_windbg/server.py` (tool schemas) and
 `src/mcp_windbg/__init__.py` (command-line options). Keep `docs/reference/` in sync with them.
 
+**The plugin has two names, and they do different jobs.** The marketplace entry in
+`.claude-plugin/marketplace.json` is named `mcp-windbg-uvx` - that is the install identity, so
+the command is `/plugin install mcp-windbg-uvx@mcp-windbg`, and it is what the plugin cache
+directory is named after. The `name` in `plugins/mcp-windbg/.claude-plugin/plugin.json` stays
+`mcp-windbg`, and that is what skills and MCP tools are scoped by: `/mcp-windbg:analyze-dump` and
+`mcp__plugin_mcp-windbg_mcp-windbg__<tool>`, whatever the entry is called.
+
+That split is deliberate. It lets a second entry ship the same plugin a different way -
+`mcp-windbg-native` for a bundled binary, `mcp-windbg-pipx` for `pipx run` - while every variant
+keeps identical skill names, identical tool names, and one set of documentation. Change
+`plugin.json`'s name and you rename every skill and every tool with it.
+
 ## Versioning and release
 
 Releases are driven by [release-please](https://github.com/googleapis/release-please). You do

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ and reports back.
 
 ```
 /plugin marketplace add svnscha/mcp-windbg
-/plugin install mcp-windbg@mcp-windbg
+/plugin install mcp-windbg-uvx@mcp-windbg
 ```
 
 The plugin launches the server with [uv](https://docs.astral.sh/uv/)'s `uvx`, which fetches the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ GitHub Copilot. Other clients work the same way once the server is configured, s
 
     ```
     /plugin marketplace add svnscha/mcp-windbg
-    /plugin install mcp-windbg@mcp-windbg
+    /plugin install mcp-windbg-uvx@mcp-windbg
     ```
 
     Then jump to [Analyze your first dump](#4-analyze-your-first-dump), or just run

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -20,7 +20,7 @@ path. It needs no `pip install` and no MCP configuration:
 
 ```
 /plugin marketplace add svnscha/mcp-windbg
-/plugin install mcp-windbg@mcp-windbg
+/plugin install mcp-windbg-uvx@mcp-windbg
 ```
 
 Alongside the ten tools you get four skills - `/mcp-windbg:analyze-dump`,

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -8,7 +8,7 @@ configuration.
 
 ```
 /plugin marketplace add svnscha/mcp-windbg
-/plugin install mcp-windbg@mcp-windbg
+/plugin install mcp-windbg-uvx@mcp-windbg
 ```
 
 The first line registers this repository as a plugin marketplace; the second installs the plugin
@@ -103,13 +103,13 @@ Note that editing the installed copy is overwritten when the plugin updates.
 
 ```
 /plugin marketplace update mcp-windbg
-/plugin update mcp-windbg@mcp-windbg
+/plugin update mcp-windbg-uvx@mcp-windbg
 ```
 
 To remove it:
 
 ```
-/plugin uninstall mcp-windbg@mcp-windbg
+/plugin uninstall mcp-windbg-uvx@mcp-windbg
 /plugin marketplace remove mcp-windbg
 ```
 

--- a/plugins/mcp-windbg/README.md
+++ b/plugins/mcp-windbg/README.md
@@ -4,7 +4,7 @@ Windows crash dump analysis and live WinDbg debugging, inside Claude Code.
 
 ```
 /plugin marketplace add svnscha/mcp-windbg
-/plugin install mcp-windbg@mcp-windbg
+/plugin install mcp-windbg-uvx@mcp-windbg
 ```
 
 That is the whole installation. There is no `pip install` step and no MCP config


### PR DESCRIPTION
Installing becomes:

```
/plugin marketplace add svnscha/mcp-windbg
/plugin install mcp-windbg-uvx@mcp-windbg
```

This frees the plain `mcp-windbg` name for a self-contained build and makes room for `mcp-windbg-pipx` beside it. Doing it **before** 1.2.0 rather than after means there is no rename migration to run: the old name was never published.

## The syntax is plugin@marketplace, not the reverse

Worth stating since it drove the shape here. `claude plugin install --help`:

> use plugin@marketplace for specific marketplace

So `mcp-windbg@uvx` would mean "plugin `mcp-windbg` from a marketplace called `uvx`" and would need three separate marketplaces. The variant has to live in the plugin name, which is what this does.

## The two names do different jobs

`plugin.json`s `name` deliberately stays `mcp-windbg`. I verified the split by installing a plugin whose two names differed on purpose:

| Name | Governs | Observed |
| :--- | :------ | :------- |
| marketplace entry | install identity, plugin cache directory | `cache/probe-mp/mcp-windbg-uvx/` |
| `plugin.json` `name` | skill and MCP tool scoping | `plugin:mcp-windbg:mcp-windbg` |

and a headless session confirmed the skills:

```
/mcp-windbg:analyze-dump
/mcp-windbg:debug-remote
/mcp-windbg:kernel-debug
/mcp-windbg:windbg-doctor
```

That is the good outcome. Every future variant keeps **identical skill names, identical tool names and one set of documentation** - only the install command differs. Renaming `plugin.json` instead would have renamed every skill and every tool with it, and split the docs three ways.

The distinction is recorded in CLAUDE.md, because nothing about the two fields makes it obvious.

## Also verified

Installed from the real marketplace under the new name:

```
Source: mcp-windbg-uvx@mcp-windbg
Skills (4)  analyze-dump, debug-remote, kernel-debug, windbg-doctor
Agents (1)  crash-analyst
MCP servers (1)  mcp-windbg
```

`claude plugin validate` passes, docs typography clean, and every occurrence of the old install command across the README, plugin README, getting-started, clients, plugin reference and CHANGELOG is updated. Test state removed afterwards.

## Note on sequencing

The open release PR (#91) predates this, so its 1.2.0 CHANGELOG entry still shows the old command. Once this merges I will delete the release branch and let release-please rebuild it, which is the documented way to refresh a release PR - `sync-lockfile` now re-does the lockfile commit on its own.