### PR TITLE
ci: skip CI on release-please pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Skip release PRs. They only carry version bumps and the CHANGELOG entry, and
+  # the full matrix runs again from publish-mcp.yml before anything ships, so the
+  # run here proves nothing. It also fails transiently: release-please pushes the
+  # version bump first and sync-lockfile updates uv.lock a moment later, so any
+  # CI in between sees a lockfile that does not match pyproject.toml and goes red
+  # on a state nobody will ever merge.
+  #
+  # head_ref is empty for push events, so those are unaffected.
   build-and-test:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     uses: ./.github/workflows/build-and-test.yml


### PR DESCRIPTION
The 1.2.0 release PR collected several red CI runs that nobody could act on:

```
CI #193: Pull request #98 synchronize by github-actions (Bot)   ✗ 6m 2s
CI #192: Pull request #98 opened by github-actions (Bot)        ✗ 6m 20s
CI #191: Pull request #91 synchronize by github-actions (Bot)   ✗ 16s
CI #190: Pull request #91 synchronize by github-actions (Bot)   ✗ 31s
```

## Why they fail

release-please pushes the version bump, and `sync-lockfile` updates `uv.lock` a moment later. CI triggered in between sees a lockfile that does not match `pyproject.toml`, fails `uv lock --check`, and reports red on a state that will never be merged. The check is right; the timing means it fires on an intermediate commit.

## Why the run is not needed at all

The release PR carries version bumps and the CHANGELOG entry. Nothing else. `publish-mcp.yml` runs the full five-version matrix again before anything reaches PyPI, and the `preflight` gate asserts every version and the CHANGELOG before a tag exists. A run on the PR proves nothing that is not proved later, with teeth.

## Correcting an earlier claim

I previously recorded that a job-level condition could not help here, because these runs are blocked at `action_required` before job conditions are evaluated. That holds for the run the bot opens on a fresh PR - but the **synchronize** runs execute normally, and those are the ones going red. A job-level `if` does work for them:

```yaml
if: ${{ !startsWith(github.head_ref, release-please--) }}
```

`head_ref` is empty on push events, so pushes to `develop` and `main` are unaffected.