### PR TITLE
feat(plugin): offer debugging skills for existing MCP servers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,19 @@
         "windows"
       ],
       "category": "development"
+    },
+    {
+      "name": "mcp-windbg-skills",
+      "source": "./plugins/mcp-windbg/skills",
+      "strict": false,
+      "description": "Four WinDbg debugging skills for an independently configured mcp-windbg server. No bundled server, launcher, or agent.",
+      "version": "1.2.2",
+      "skills": ["./analyze-dump", "./debug-remote", "./kernel-debug", "./windbg-doctor"],
+      "author": { "name": "Sven Scharmentke" },
+      "homepage": "https://svnscha.github.io/mcp-windbg/reference/plugin/",
+      "repository": "https://github.com/svnscha/mcp-windbg",
+      "license": "MIT",
+      "category": "development"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the MCP Server for WinDbg Crash Analysis project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- A `mcp-windbg-skills` Claude Code plugin with the four shared debugging skills
+  for independently configured MCP servers, without a bundled server or agent.
+
+### Changed
+
+- Skills resolve tools from the configured server; setup diagnosis checks its
+  actual launcher and host instead of requiring uv for every installation.
+- Release validation checks the version of every marketplace entry.
+- README and setup documentation explain both plugin choices, their skill names,
+  switching and updating, and the separate built-in MCP prompts.
+
 ## [1.2.2] - 2026-09-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ That split is deliberate. It lets a second entry ship the same plugin a differen
 keeps identical skill names, identical tool names, and one set of documentation. Change
 `plugin.json`'s name and you rename every skill and every tool with it.
 
+The skills-only entry `mcp-windbg-skills` is different: its source is
+`plugins/mcp-windbg/skills`, and `strict: false` makes the marketplace entry its
+manifest. It exposes those four shared directories without the parent plugin's
+MCP configuration or agent. Its skill namespace is `/mcp-windbg-skills:...`.
+Keep shared skills independent of launcher and tool namespace. The existing
+marketplace version wildcard updates both entries; the release check must check both.
+
 ## Versioning and release
 
 Releases are driven by [release-please](https://github.com/googleapis/release-please). You do

--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ Parameters, timeouts, and the built-in triage prompts are in the [tools referenc
 
 ## Quick start
 
-> [!TIP]
-> In enterprise environments, MCP server usage might be restricted by organizational policies. Check with your IT team about AI tool usage and ensure you have the necessary permissions before proceeding.
+> [!NOTE]
+> **Claude Code in enterprise environments:** when managed settings define `allowedMcpServers`,
+> plugin-bundled MCP servers may be silently skipped ([Claude Code issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
+> We recommend [installing and registering the server manually](#registering-the-server-yourself),
+> then adding the [skills-only plugin](#skills-for-an-existing-server).
+> The server must still be permitted by your organization's MCP policy.
 
 **Prerequisites**
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Parameters, timeouts, and the built-in triage prompts are in the [tools referenc
 > [!NOTE]
 > **Claude Code in enterprise environments:** when managed settings define `allowedMcpServers`,
 > plugin-bundled MCP servers may be silently skipped ([Claude Code issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
-> We recommend [installing and registering the server manually](#registering-the-server-yourself),
+> I recommend [installing and registering the server manually](#registering-the-server-yourself),
 > then adding the [skills-only plugin](#skills-for-an-existing-server).
 > The server must still be permitted by your organization's MCP policy.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,14 @@ Python is not a prerequisite in itself. Each route below states what it needs.
 
 ## Install in Claude Code
 
-### The plugin
+Choose the plugin that matches your setup:
+
+| Plugin | Server | Included workflows |
+| --- | --- | --- |
+| `mcp-windbg-uvx` | Launched by the plugin with uvx | Four skills and the `crash-analyst` agent |
+| `mcp-windbg-skills` | Your existing MCP connection | The same four skills |
+
+### Server and skills with uvx
 
 The shortest path: two lines, no `pip install`, no MCP configuration to edit. Adds four
 skills and a `crash-analyst` agent on top of the ten tools, with symbols preconfigured.
@@ -96,7 +103,26 @@ pip install mcp-windbg
 claude mcp add mcp-windbg -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- python -m mcp_windbg
 ```
 
-Needs Python 3.10 or higher. The tools are identical; the skills and the agent are not included.
+Needs Python 3.10 or higher. Add the optional skills plugin below for the guided workflows.
+
+### Skills for an existing server
+
+After installing and registering mcp-windbg yourself, add just the four skills:
+
+```text
+/plugin marketplace add svnscha/mcp-windbg
+/plugin install mcp-windbg-skills@mcp-windbg
+```
+
+Invoke `/mcp-windbg-skills:analyze-dump`, `/mcp-windbg-skills:debug-remote`,
+`/mcp-windbg-skills:kernel-debug`, or `/mcp-windbg-skills:windbg-doctor`.
+This plugin uses your configured MCP connection and adds no server, runtime,
+symbol settings, or `crash-analyst` agent. It works with a native executable,
+Python installation, or HTTP service exposing the mcp-windbg tools.
+Choose this plugin or the uvx bundle; installing both duplicates the skills.
+The server's [built-in MCP prompts](https://svnscha.github.io/mcp-windbg/reference/prompts/)
+remain available independently of either plugin. See the
+[plugin guide](https://svnscha.github.io/mcp-windbg/reference/plugin/) for updating or switching plugins.
 
 ## Install in another client
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,17 +5,21 @@ GitHub Copilot. Other clients work the same way once the server is configured, s
 [Client configuration](reference/clients.md).
 
 !!! tip "Using Claude Code?"
-    Skip the VS Code steps and install the [plugin](reference/plugin.md) instead. There is no
+    Skip the VS Code steps and install the [uvx plugin](reference/plugin.md#server-and-skills-with-uvx). There is no
     `pip install` and nothing to configure - symbols included:
 
-    ```
+    ```text
     /plugin marketplace add svnscha/mcp-windbg
     /plugin install mcp-windbg-uvx@mcp-windbg
     ```
 
     Then jump to [Analyze your first dump](#4-analyze-your-first-dump), or just run
-    `/mcp-windbg:analyze-dump`. You still need the prerequisites in step 1, plus
-    [uv](https://docs.astral.sh/uv/).
+    `/mcp-windbg:analyze-dump`. This route needs Windows debugging tools and
+    [uv](https://docs.astral.sh/uv/); a separate Python installation is not required.
+
+    Already registered mcp-windbg yourself? Add the
+    [skills-only plugin](reference/plugin.md#skills-for-an-existing-server) and use
+    `/mcp-windbg-skills:analyze-dump` with your existing connection.
 
 ## 1. Check the prerequisites
 

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -13,12 +13,12 @@ server. Adjust the path or add more locations as needed. For running from a chec
 
 ## Claude Code
 
-### The plugin (recommended)
+### Server and skills with uvx
 
-The [plugin](https://github.com/svnscha/mcp-windbg/tree/main/plugins/mcp-windbg) is the shortest
+The [uvx plugin](plugin.md#server-and-skills-with-uvx) is the shortest
 path. It needs no `pip install` and no MCP configuration:
 
-```
+```text
 /plugin marketplace add svnscha/mcp-windbg
 /plugin install mcp-windbg-uvx@mcp-windbg
 ```
@@ -64,6 +64,20 @@ Claude Code records the server in `.claude.json`:
 Add server options such as a [filter script](../scenarios/redaction.md) after the command,
 for example `-- python -m mcp_windbg --filter-script C:\filters\pii_redaction.py`. Run
 `claude mcp list` to confirm it connected.
+
+### Skills for an existing server
+
+After registering your server, add the four workflows with the
+[skills-only plugin](plugin.md#skills-for-an-existing-server):
+
+```text
+/plugin marketplace add svnscha/mcp-windbg
+/plugin install mcp-windbg-skills@mcp-windbg
+```
+
+Use `/mcp-windbg-skills:analyze-dump` to start. The plugin uses your existing
+connection, including an HTTP service, and does not require uv or change the
+server's launch command, symbol settings, or version.
 
 ## Claude Desktop
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,8 +7,8 @@ The precise, lookup-style reference for `mcp-windbg`.
 - **[Tools](tools.md)** - the MCP tools the server exposes, their parameters, and the
   WinDbg commands that come up most often.
 - **[Prompts](prompts.md)** - the built-in `dump-triage`, `remote-triage`, and `kernel-triage` prompts.
-- **[Claude Code plugin](plugin.md)** - the one-command install for Claude Code, and the
-  skills and agent it brings with it.
+- **[Claude Code plugins](plugin.md)** - the uvx bundle with skills and an agent, or
+  just the skills for an existing MCP server.
 - **[Client configuration](clients.md)** - configuration snippets for VS Code, Claude
   Desktop, and GitHub Copilot CLI, plus pip and from-source installs.
 

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -1,124 +1,126 @@
-# Claude Code plugin
+# Claude Code plugins
 
-The plugin is the shortest way to use mcp-windbg from Claude Code. It brings the
-[tools](tools.md), a set of skills, and an agent, and it needs no `pip install` and no MCP
-configuration.
+Choose a plugin based on how you run the server:
+
+| Plugin | Server | Included workflows |
+| --- | --- | --- |
+| `mcp-windbg-uvx` | Launches the pinned server with uvx | Four skills and the `crash-analyst` agent |
+| `mcp-windbg-skills` | Uses your existing MCP connection | The same four skills |
 
 ## Install
 
-```
+### Server and skills with uvx
+
+```text
 /plugin marketplace add svnscha/mcp-windbg
 /plugin install mcp-windbg-uvx@mcp-windbg
 ```
 
-The first line registers this repository as a plugin marketplace; the second installs the plugin
-from it. Restart Claude Code if the tools do not appear straight away.
+This bundle supplies the ten [tools](tools.md), skills, an agent, and default symbol
+settings. It needs Windows with [Debugging Tools for Windows](https://aka.ms/windbg)
+and [uv](https://docs.astral.sh/uv/) on `PATH` (`winget install astral-sh.uv`).
+No separate Python or package installation is required.
 
-## What you get
+### Skills for an existing server
 
-All ten [tools](tools.md), plus:
-
-| Skill | What it does |
-| :---- | :----------- |
-| `/mcp-windbg:analyze-dump` | Triage a crash dump - exception, faulting frame, and what the evidence supports |
-| `/mcp-windbg:debug-remote` | Attach to a running process through a WinDbg debug server |
-| `/mcp-windbg:kernel-debug` | Drive a live kernel target, including resuming it and waiting for a break |
-| `/mcp-windbg:windbg-doctor` | Check whether this machine can debug at all, and what to fix |
-
-And one agent:
-
-- **`crash-analyst`** investigates a dump on its own and reports back a verdict, the evidence
-  behind it, what it ruled out, and what to do next. Use it when a dump needs more than a first
-  look, or to keep a long analysis out of your main conversation.
-
-Ask for it by name: *"use the crash-analyst agent on C:\dumps\app.dmp"*.
-
-## Requirements
-
-- **Windows.** The server drives `cdb.exe` and `kd.exe`. A plugin manifest has no field for
-  declaring a platform, so this is not enforced at install time - on macOS or Linux the plugin
-  loads and the server then fails to find a debugger.
-- **Debugging Tools for Windows**, for `cdb.exe`. Install [WinDbg](https://aka.ms/windbg) from the
-  Microsoft Store, or the Windows SDK.
-- **[uv](https://docs.astral.sh/uv/)**, which provides `uvx`. This is the one prerequisite the
-  plugin cannot supply for you: `winget install astral-sh.uv`.
-
-Run `/mcp-windbg:windbg-doctor` if you are unsure - it checks all three and tells you what is
-missing.
-
-## How it runs the server
-
-The plugin does not require the package to be installed. It launches the server with `uvx`,
-pinned to the release that matches the plugin version:
-
-```json title="plugins/mcp-windbg/.mcp.json"
-{
-  "mcpServers": {
-    "mcp-windbg": {
-      "command": "uvx",
-      "args": ["mcp-windbg@1.1.0"],
-      "env": {
-        "_NT_SYMBOL_PATH": "${_NT_SYMBOL_PATH:-SRV*C:\\Symbols*https://msdl.microsoft.com/download/symbols}"
-      }
-    }
-  }
-}
+```text
+/plugin marketplace add svnscha/mcp-windbg
+/plugin install mcp-windbg-skills@mcp-windbg
 ```
 
-`uvx` fetches that version from PyPI on first use and caches it. Pinning keeps the plugin and the
-server it drives in step, so a plugin update is what moves the server version.
+First [register mcp-windbg directly](clients.md#registering-the-server-directly),
+or use a connection you already configured. The skills work with a native executable,
+Python installation, or [HTTP service](../scenarios/http-service.md) exposing the
+mcp-windbg tools. Windows and CDB/KD are required on the server host; an HTTP client
+can run elsewhere. uv is needed only if your own server command uses it.
 
-## Symbols
+The skills-only plugin adds no server, runtime, agent, or symbol settings. It resolves
+its tool calls through your existing MCP connection. If tools are missing, run
+`/mcp-windbg-skills:windbg-doctor` to check that connection and its actual launcher.
 
-Symbols work out of the box. The `${VAR:-default}` form above means:
+Both plugins come from the same marketplace. Choose one to avoid duplicate skills.
+Restart Claude Code if newly installed skills or tools do not appear.
 
-- **No `_NT_SYMBOL_PATH` set** - the plugin supplies the Microsoft symbol server, caching to
-  `C:\Symbols`.
-- **`_NT_SYMBOL_PATH` already set** - your value wins and the default is ignored. A symbol path
-  you tuned yourself is never overwritten.
+## Skills
 
-To use your own, set it in the environment before starting Claude Code:
+Both plugins use the same four skill files. Their invocation prefixes differ:
+
+| Workflow | uvx bundle | Skills-only plugin |
+| --- | --- | --- |
+| Triage a crash dump | `/mcp-windbg:analyze-dump` | `/mcp-windbg-skills:analyze-dump` |
+| Debug a live user-mode process | `/mcp-windbg:debug-remote` | `/mcp-windbg-skills:debug-remote` |
+| Drive a live kernel target | `/mcp-windbg:kernel-debug` | `/mcp-windbg-skills:kernel-debug` |
+| Diagnose the debugging setup | `/mcp-windbg:windbg-doctor` | `/mcp-windbg-skills:windbg-doctor` |
+
+For example, with an independently installed server:
+
+```text
+/mcp-windbg-skills:analyze-dump C:\dumps\app.dmp
+```
+
+The server's built-in [MCP prompts](prompts.md) remain available with or without a
+plugin. They are separate from these Claude Code skills.
+
+The uvx bundle also includes **`crash-analyst`**, an agent that investigates a dump
+and reports its verdict, evidence, and next steps. Ask for it by name:
+*"use the crash-analyst agent on C:\dumps\app.dmp"*. The skills-only plugin does not
+include this agent.
+
+## Server options and symbols
+
+The uvx bundle launches the server using its `.mcp.json`, pinned to the matching
+release. uvx fetches that version from PyPI on first use and caches it. Updating
+the bundle updates the pinned server too.
+
+The bundle supplies `_NT_SYMBOL_PATH` with the Microsoft symbol server and a
+`C:\Symbols` cache only when you have not set your own value. To customize it:
 
 ```powershell
 setx _NT_SYMBOL_PATH "SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols;C:\my\pdbs"
 ```
 
-`setx` only affects new processes, so restart the terminal. Check what the server actually
-received with `/mcp`.
+Restart the terminal and Claude Code so new processes inherit the value.
 
-Without symbols, stacks resolve to `module+0x1234` and any analysis built on them is guesswork -
-which is why the plugin defaults to something that works rather than to nothing.
+With the skills-only plugin, configure symbols and [command-line options](cli.md)
+in your own server registration. Updating skills does not update the server or its
+configuration. Use `--symbols-path` or `_NT_SYMBOL_PATH` on the server host; the
+client shell's value may differ, especially over HTTP.
 
-## Passing other options
+For custom `--cdb-path`, `--kd-path`, `--filter-script`, or timeout settings,
+[register the server directly](clients.md#registering-the-server-directly) and add
+the skills-only plugin. Edits to the installed uvx bundle are overwritten on update.
 
-The [command-line options](cli.md) are set in the plugin's `.mcp.json` `args`. To add one - a
-custom `--cdb-path`, a `--filter-script`, a longer `--timeout` - edit that file in the installed
-plugin, or install the server directly instead (see
-[Client configuration](clients.md#registering-the-server-directly)), which gives you full control
-of the command line at the cost of the bundled skills and agent.
+## Switch from the uvx bundle
 
-Note that editing the installed copy is overwritten when the plugin updates.
+Finish open debugging sessions, then uninstall the bundle:
+
+```text
+/plugin uninstall mcp-windbg-uvx@mcp-windbg
+```
+
+[Register your server](clients.md#registering-the-server-directly), install
+`mcp-windbg-skills@mcp-windbg` as above, and restart Claude Code. Confirm the server
+connection with `/mcp`, then run `/mcp-windbg-skills:windbg-doctor`. Your skill
+invocations now use the `mcp-windbg-skills` prefix.
 
 ## Updating and removing
 
-```
+For the skills-only plugin:
+
+```text
 /plugin marketplace update mcp-windbg
-/plugin update mcp-windbg-uvx@mcp-windbg
+/plugin update mcp-windbg-skills@mcp-windbg
 ```
 
-To remove it:
+For the uvx bundle, substitute `mcp-windbg-uvx@mcp-windbg` in the update command.
 
+To remove the skills-only plugin:
+
+```text
+/plugin uninstall mcp-windbg-skills@mcp-windbg
 ```
-/plugin uninstall mcp-windbg-uvx@mcp-windbg
-/plugin marketplace remove mcp-windbg
-```
 
-## Not using uv
-
-Install the package yourself and register the server directly. You lose the skills and the agent,
-but the tools are identical:
-
-```powershell
-pip install mcp-windbg
-claude mcp add mcp-windbg -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- python -m mcp_windbg
-```
+Your independently registered MCP server remains configured. For the bundle,
+uninstall `mcp-windbg-uvx@mcp-windbg` instead; that also removes its server registration.
+Remove the marketplace with `/plugin marketplace remove mcp-windbg` when neither
+plugin is needed.

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -7,6 +7,13 @@ Choose a plugin based on how you run the server:
 | `mcp-windbg-uvx` | Launches the pinned server with uvx | Four skills and the `crash-analyst` agent |
 | `mcp-windbg-skills` | Uses your existing MCP connection | The same four skills |
 
+!!! note "Enterprise environments"
+    Managed `allowedMcpServers` settings can cause Claude Code to silently skip
+    plugin-bundled MCP servers ([issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
+    We recommend [manual server installation and registration](clients.md#registering-the-server-directly)
+    plus the [skills-only plugin](#skills-for-an-existing-server).
+    The server must still be permitted by your organization's MCP policy.
+
 ## Install
 
 ### Server and skills with uvx

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -10,7 +10,7 @@ Choose a plugin based on how you run the server:
 !!! note "Enterprise environments"
     Managed `allowedMcpServers` settings can cause Claude Code to silently skip
     plugin-bundled MCP servers ([issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
-    We recommend [manual server installation and registration](clients.md#registering-the-server-directly)
+    I recommend [manual server installation and registration](clients.md#registering-the-server-directly)
     plus the [skills-only plugin](#skills-for-an-existing-server).
     The server must still be permitted by your organization's MCP policy.
 

--- a/docs/reference/prompts.md
+++ b/docs/reference/prompts.md
@@ -5,6 +5,10 @@ instructions your client can insert into the conversation; most clients surface 
 slash command or a prompt picker. Selecting one is optional, the [tools](tools.md) work
 without it.
 
+These prompts ship with the MCP server and require no Claude Code plugin. The
+[plugin skills](plugin.md#skills) are separate workflows installed in Claude Code;
+the skills-only plugin adds them to an existing server connection.
+
 In VS Code a prompt appears as a slash command (for example `/mcp.mcp-windbg.dump-triage`);
 other clients list them in a prompt menu. Each takes one optional argument: pass it and the
 model starts on that target, omit it and the model asks.

--- a/plugins/mcp-windbg/README.md
+++ b/plugins/mcp-windbg/README.md
@@ -5,7 +5,7 @@ Windows crash dump analysis and live WinDbg debugging, inside Claude Code.
 > [!NOTE]
 > **Enterprise environments:** managed `allowedMcpServers` settings can cause Claude Code to
 > silently skip this plugin's MCP server ([issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
-> We recommend [manual server installation and registration](#not-using-uv) plus the
+> I recommend [manual server installation and registration](#not-using-uv) plus the
 > [skills-only plugin](#skills-for-an-existing-server), subject to your organization's MCP policy.
 
 ```

--- a/plugins/mcp-windbg/README.md
+++ b/plugins/mcp-windbg/README.md
@@ -2,6 +2,12 @@
 
 Windows crash dump analysis and live WinDbg debugging, inside Claude Code.
 
+> [!NOTE]
+> **Enterprise environments:** managed `allowedMcpServers` settings can cause Claude Code to
+> silently skip this plugin's MCP server ([issue #32882](https://github.com/anthropics/claude-code/issues/32882)).
+> We recommend [manual server installation and registration](#not-using-uv) plus the
+> [skills-only plugin](#skills-for-an-existing-server), subject to your organization's MCP policy.
+
 ```
 /plugin marketplace add svnscha/mcp-windbg
 /plugin install mcp-windbg-uvx@mcp-windbg

--- a/plugins/mcp-windbg/README.md
+++ b/plugins/mcp-windbg/README.md
@@ -1,4 +1,4 @@
-# mcp-windbg plugin
+# mcp-windbg uvx plugin
 
 Windows crash dump analysis and live WinDbg debugging, inside Claude Code.
 
@@ -10,6 +10,9 @@ Windows crash dump analysis and live WinDbg debugging, inside Claude Code.
 That is the whole installation. There is no `pip install` step and no MCP config
 to edit - the plugin launches the server with `uvx`, which fetches the pinned
 version from PyPI on first use.
+
+Already have an MCP server configured? Install the
+[skills-only plugin](#skills-for-an-existing-server) to use the same workflows with it.
 
 ## What you get
 
@@ -33,8 +36,8 @@ Four skills:
   debug server and work out a hang or a live fault.
 - **`/mcp-windbg:kernel-debug`** - drive a live kernel target, including resuming
   the machine and waiting for a bugcheck or breakpoint.
-- **`/mcp-windbg:windbg-doctor`** - check that this machine can debug at all
-  (CDB, uv, symbols) and explain what to fix. Start here when something fails.
+- **`/mcp-windbg:windbg-doctor`** - check the MCP connection, server launcher,
+  debugger, and symbols. Start here when something fails.
 
 And an agent:
 
@@ -79,17 +82,32 @@ why this defaults to something that works rather than to nothing.
 
 ## Not using uv
 
-The plugin pins the server version so the plugin and the server it drives stay
-in lockstep. To run it a different way, install the package yourself and point
-the config at it - edit `.mcp.json` in the installed plugin, or skip the plugin
-and register the server directly:
+To control the server's installation and version yourself, register it directly:
 
 ```powershell
 pip install mcp-windbg
 claude mcp add mcp-windbg -s user -e _NT_SYMBOL_PATH="SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols" -- python -m mcp_windbg
 ```
 
-You lose the bundled skills that way, but the tools are identical.
+### Skills for an existing server
+
+After installing and registering mcp-windbg yourself, add just the four skills:
+
+```text
+/plugin marketplace add svnscha/mcp-windbg
+/plugin install mcp-windbg-skills@mcp-windbg
+```
+
+Invoke `/mcp-windbg-skills:analyze-dump`, `/mcp-windbg-skills:debug-remote`,
+`/mcp-windbg-skills:kernel-debug`, or `/mcp-windbg-skills:windbg-doctor`.
+This plugin uses your configured MCP connection and adds no server, runtime,
+symbol settings, or `crash-analyst` agent. It works with a native executable,
+Python installation, or HTTP service exposing the mcp-windbg tools.
+Choose this plugin or the uvx bundle; installing both duplicates the skills.
+The server's built-in MCP prompts remain available independently of either plugin.
+Updating this plugin updates only the skills; update your server separately.
+See the [plugin guide](https://svnscha.github.io/mcp-windbg/reference/plugin/)
+for switching from the uvx bundle, updating, and removing either plugin.
 
 ## Links
 

--- a/plugins/mcp-windbg/skills/analyze-dump/SKILL.md
+++ b/plugins/mcp-windbg/skills/analyze-dump/SKILL.md
@@ -5,6 +5,16 @@ description: Triage a Windows crash dump - identify the exception, the faulting 
 
 # Analyze a Windows crash dump
 
+## MCP connection
+
+Use the existing mcp-windbg MCP connection, whether it is launched by a plugin,
+a native executable, Python, or an HTTP service. Tool names below are base
+names; resolve them against the tools exposed by that connection rather than
+assuming a plugin-specific prefix. Keep each session on the server that opened
+it. If multiple servers match, use the user's selected server or ask which one.
+If the required tools are unavailable, report the missing connection or tool
+and help check its configuration; do not register a second server.
+
 Work through a `.dmp` file with the `mcp-windbg` tools and report what actually
 crashed, not just what the debugger printed.
 

--- a/plugins/mcp-windbg/skills/debug-remote/SKILL.md
+++ b/plugins/mcp-windbg/skills/debug-remote/SKILL.md
@@ -5,8 +5,18 @@ description: Attach to a running Windows process through a WinDbg debug server a
 
 # Debug a live user-mode process
 
+## MCP connection
+
+Use the existing mcp-windbg MCP connection, whether it is launched by a plugin,
+a native executable, Python, or an HTTP service. Tool names below are base
+names; resolve them against the tools exposed by that connection rather than
+assuming a plugin-specific prefix. Keep each session on the server that opened
+it. If multiple servers match, use the user's selected server or ask which one.
+If the required tools are unavailable, report the missing connection or tool
+and help check its configuration; do not register a second server.
+
 Attach to an existing WinDbg/CDB **debug server** with the `mcp-windbg` tools.
-This is user-mode only - for a kernel target use `/mcp-windbg:kernel-debug`.
+This is user-mode only - for a kernel target use the available `kernel-debug` skill.
 
 ## The other end
 

--- a/plugins/mcp-windbg/skills/kernel-debug/SKILL.md
+++ b/plugins/mcp-windbg/skills/kernel-debug/SKILL.md
@@ -5,6 +5,16 @@ description: Attach to a live Windows kernel target over KDNET, a named pipe, or
 
 # Debug a live Windows kernel target
 
+## MCP connection
+
+Use the existing mcp-windbg MCP connection, whether it is launched by a plugin,
+a native executable, Python, or an HTTP service. Tool names below are base
+names; resolve them against the tools exposed by that connection rather than
+assuming a plugin-specific prefix. Keep each session on the server that opened
+it. If multiple servers match, use the user's selected server or ask which one.
+If the required tools are unavailable, report the missing connection or tool
+and help check its configuration; do not register a second server.
+
 Drive a kernel target with the `mcp-windbg` kd tools. A kernel session halts the
 whole machine while it is broken in, so treat the target's running state as
 something you are responsible for.

--- a/plugins/mcp-windbg/skills/windbg-doctor/SKILL.md
+++ b/plugins/mcp-windbg/skills/windbg-doctor/SKILL.md
@@ -1,49 +1,64 @@
 ---
 name: windbg-doctor
-description: Check that this machine can actually debug - CDB present, uv available, symbols configured - and explain how to fix whatever is missing. Use when mcp-windbg tools fail, when a session will not open, or before a first debugging session.
+description: Check that this machine can actually debug - MCP connection reachable, debugger present, symbols configured - and explain how to fix whatever is missing. Use when mcp-windbg tools fail, when a session will not open, or before a first debugging session.
 ---
 
 # Check the debugging setup
+
+## MCP connection
+
+Use the existing mcp-windbg MCP connection, whether it is launched by a plugin,
+a native executable, Python, or an HTTP service. Tool names below are base
+names; resolve them against the tools exposed by that connection rather than
+assuming a plugin-specific prefix. Keep each session on the server that opened
+it. If multiple servers match, use the user's selected server or ask which one.
+If the required tools are unavailable, report the missing connection or tool
+and help check its configuration; do not register a second server.
 
 Diagnose why mcp-windbg is not working, or confirm it will before someone
 relies on it. Report findings together at the end, not one command at a time.
 
 ## Checks
 
-Run these with Bash and interpret the results.
+Inspect the configured MCP transport and launch command first. Run host checks
+on the machine running the server, using its available shell. For an HTTP
+service, local client checks do not describe the server; use server diagnostics
+or ask its operator for evidence and mark unavailable checks as unverified.
 
-**1. Platform.** `uname -s` or `$env:OS`. The server drives `cdb.exe`/`kd.exe`
-and is Windows-only. On anything else, stop here and say so - nothing later will
-help.
+**1. Tools reachable.** Call `list_dumps` through the configured connection.
+A successful response, including an empty list, proves the MCP round trip works;
+it does not prove that CDB or KD can start. If connection fails, inspect the
+client's MCP status and server logs.
 
-**2. CDB.** Look in the places the server itself searches:
+**2. Platform and debugger.** The server host must be Windows. Check configured
+`--cdb-path` / `--kd-path` overrides and the debugger locations the server searches:
 
-```
+```text
 C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe
 %LOCALAPPDATA%\Microsoft\WindowsApps\cdbX64.exe
 ```
 
-Missing means WinDbg is not installed. Point at
-[aka.ms/windbg](https://aka.ms/windbg) (Microsoft Store) or the Windows SDK's
-Debugging Tools for Windows. If it is installed somewhere unusual, the server
-takes `--cdb-path` / `--kd-path`.
+Check KD as well for kernel debugging. If the debugger is missing, point at
+[aka.ms/windbg](https://aka.ms/windbg) or the Windows SDK's Debugging Tools for
+Windows. Do not infer that the debugger is missing from a client-side path check.
 
-**3. uv.** `uv --version`. The plugin launches the server with `uvx`, so a
-missing uv means the MCP server never starts and every tool fails at once.
-`winget install astral-sh.uv`.
+**3. Launcher.** Check only the runtime used by the configured server command:
 
-**4. The server itself.** `uvx mcp-windbg --help`. This proves the whole chain -
-uv resolves the package from PyPI and the entry point runs. A failure here with
-uv present usually means no network, or a proxy blocking PyPI.
+- `uvx`: check `uv --version` and run the configured package spec with `--help`,
+  preserving its version pin. Resolution failures can indicate network or proxy
+  problems. uv is required only for this launch method.
+- Python or a console entry point: use the configured interpreter or executable
+  with `--help` (for example `python -m mcp_windbg --help`).
+- Native executable: check that exact executable with `--help`; do not require
+  Python or uv.
+- HTTP: check the configured endpoint and server logs; do not launch a local
+  replacement server.
 
-**5. Symbols.** Check `_NT_SYMBOL_PATH`. The plugin defaults it to the Microsoft
-symbol server, so an empty value in the *shell* is not a problem by itself -
-what matters is what the server received. Report the effective value and note
-that without symbols, stacks resolve only to `module+0x1234` and any analysis
-built on them is guesswork.
-
-**6. Tools reachable.** If the MCP server is up, `list_dumps` returning anything
-at all - including "no dumps found" - proves the round trip works.
+**4. Symbols.** Inspect `--symbols-path`, the server's `_NT_SYMBOL_PATH`, and,
+if a debugger session is already open, `.sympath`. The uvx plugin supplies a
+default symbol path; independently configured servers may not. An empty client
+shell variable does not establish the server's effective value. Report unknown
+values as unverified. Missing symbols limit what stack offsets can tell you.
 
 ## Reporting
 

--- a/scripts/check-version-consistency.ps1
+++ b/scripts/check-version-consistency.ps1
@@ -5,7 +5,7 @@
 
 .DESCRIPTION
     Extracts the version from pyproject.toml, server.json (top level and package),
-    .release-please-manifest.json, the Claude plugin manifest, the marketplace entry and the
+    .release-please-manifest.json, the Claude plugin manifest, every marketplace entry and the
     server version pinned in the plugin's .mcp.json, and checks they all match. Also checks that
     CHANGELOG.md's top heading names that version and has an entry underneath it.
 
@@ -80,11 +80,13 @@ try {
     # kept in step by release-please extra-files entries; checking them here is
     # what catches an entry that silently stopped matching.
     $PLUGIN_VERSION = (Get-Content "plugins/mcp-windbg/.claude-plugin/plugin.json" -Raw | ConvertFrom-Json).version
-    $MARKETPLACE_VERSION = (Get-Content ".claude-plugin/marketplace.json" -Raw | ConvertFrom-Json).plugins[0].version
+    $marketplacePlugins = (Get-Content ".claude-plugin/marketplace.json" -Raw | ConvertFrom-Json).plugins
     $mcpArgs = (Get-Content "plugins/mcp-windbg/.mcp.json" -Raw | ConvertFrom-Json).mcpServers.'mcp-windbg'.args
     $PINNED_VERSION = ($mcpArgs[0] -split '@')[-1]
     Write-Host "INFO: plugin.json version: $PLUGIN_VERSION" -ForegroundColor Green
-    Write-Host "INFO: marketplace.json plugin version: $MARKETPLACE_VERSION" -ForegroundColor Green
+    foreach ($plugin in $marketplacePlugins) {
+        Write-Host "INFO: marketplace $($plugin.name): $($plugin.version)" -ForegroundColor Green
+    }
     Write-Host "INFO: plugin .mcp.json pinned server: $PINNED_VERSION" -ForegroundColor Green
 
     # Check if all versions match
@@ -94,8 +96,10 @@ try {
         $errors += "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != plugin.json ($PLUGIN_VERSION)"
     }
 
-    if ($PYPROJECT_VERSION -ne $MARKETPLACE_VERSION) {
-        $errors += "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != marketplace.json ($MARKETPLACE_VERSION)"
+    foreach ($plugin in $marketplacePlugins) {
+        if ($PYPROJECT_VERSION -ne $plugin.version) {
+            $errors += "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != marketplace $($plugin.name) ($($plugin.version))"
+        }
     }
 
     if ($PYPROJECT_VERSION -ne $PINNED_VERSION) {


### PR DESCRIPTION
Superseded by #106 after renaming the source branch to `feat/skills-only-plugin`.

## What this changes

Users who register mcp-windbg independently can install `mcp-windbg-skills@mcp-windbg` to get the same four debugging skills as the uvx bundle. The new entry packages the existing skill directories without a server configuration or agent, so it works with native, Python, or HTTP server connections without launching another server.

Skills resolve tool names through the selected MCP connection. `windbg-doctor` checks the actual server host and launcher instead of requiring uv for every installation. The uvx bundle retains its existing workflows and invocation names.

The README, plugin guide, client setup, getting-started guide, and prompts reference explain both plugin choices, their invocation prefixes, switching and updating, and the distinction between skills and built-in MCP prompts. Release validation now checks every marketplace entry; the existing release-please wildcard keeps their versions aligned.

## How it was verified

- `mkdocs build --strict` passed using the repository's documentation requirements in an isolated uv environment.
- Markdown typography, `git diff --check`, and Claude marketplace/plugin manifest validation passed.
- Installed `mcp-windbg-skills` from the local marketplace into a temporary Claude configuration; verified all four skill files were installed without an MCP server configuration.
- Release-check fixtures accepted matching 1.2.2 versions and rejected version drift in either marketplace entry. The actual changelog retains its Unreleased heading for release-please's release PR.

The installation check did not exercise model-driven debugging or a live target. No server runtime code changed.
